### PR TITLE
Updating discoverResources function to ensure that matched `href` or `src` attributes always have a space in front of them.

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,7 +249,7 @@ var Crawler = function(domain,initialPath,initialPort,interval) {
 		function cleanAndQueue(urlMatch) {
 			if (urlMatch) {
 				urlMatch.forEach(function(URL) {
-					URL = URL.replace(/^(href|src)=['"]?/i,"").replace(/^\s*/,"");
+					URL = URL.replace(/^(\s?href|\s?src)=['"]?/i,"").replace(/^\s*/,"");
 					URL = URL.replace(/^url\(['"]*/i,"");
 					URL = URL.replace(/^javascript\:[a-z0-9]+\(['"]/i,"");
 					URL = URL.replace(/["'\)]$/i,"");
@@ -275,7 +275,7 @@ var Crawler = function(domain,initialPath,initialPort,interval) {
 		}
 
 		// Rough scan for URLs
-		cleanAndQueue(resourceText.match(/(href\s?=\s?|src\s?=\s?|url\()['"]?([^"'\s>\)]+)/ig));
+		cleanAndQueue(resourceText.match(/(\shref\s?=\s?|\ssrc\s?=\s?|url\()['"]?([^"'\s>\)]+)/ig));
 		cleanAndQueue(resourceText.match(/http(s)?\:\/\/[^?\s><\'\"]+/ig));
 		cleanAndQueue(resourceText.match(/url\([^)]+/ig));
 


### PR DESCRIPTION
... This resolves an issue we have with incorrect matches on embedded GoogleAnalytics code.

The standard GA code has something like:

``` javascript
ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
```

This was causing request for resources that did not exist.
