### PR TITLE
Issue with queue items and domain namespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ var Crawler = function(host,initialPath,initialPort,interval) {
 
 		if (URLContext) {
 			port = URLContext.port;
-			host = URLContext.domain;
+			host = URLContext.host;
 			protocol = URLContext.protocol;
 			path = URLContext.path;
 		}

--- a/queue.js
+++ b/queue.js
@@ -42,7 +42,7 @@ FetchQueue.prototype.add = function(protocol,domain,port,path,callback) {
 				var queueItem = {
 					"url": url,
 					"protocol": protocol,
-					"domain": domain,
+					"host": domain,
 					"port": port,
 					"path": path,
 					"fetched": false,


### PR DESCRIPTION
I fixed a bug with queue items not being processed correctly due to a cross match of domain and host on the returned queueItem object. This pull request should fix that.
