### PR TITLE
Fixed: Work out why test suite is failing in Travis on 0.10 but not in 0.10 locally

### DIFF
--- a/test/testcrawl.js
+++ b/test/testcrawl.js
@@ -17,6 +17,9 @@ describe("Test Crawl",function() {
 	it("should be able to be started",function(done) {
 
 		localCrawler.on("crawlstart",done);
+		localCrawler.on("discoverycomplete",function() {
+			linksDiscovered ++;
+		});
 
 		localCrawler.start();
 		localCrawler.running.should.be.truthy;
@@ -28,10 +31,6 @@ describe("Test Crawl",function() {
 	});
 
 	it("should discover all linked resources in the queue",function(done) {
-
-		localCrawler.on("discoverycomplete",function() {
-			linksDiscovered ++;
-		});
 
 		localCrawler.on("complete",function() {
 			linksDiscovered.should.equal(5);


### PR DESCRIPTION
'twas merely a race condition in a test. I imagine that somehow the initial crawl was happening before the mocha test was able to bind its event listener.

fixes cgiffard/node-simplecrawler#36
