### PR TITLE
Stop overriding default port configurations

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -654,6 +654,11 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
 			"User-Agent": crawler.userAgent
 		}
 	};
+	
+	// If port is one of the HTTP/HTTPS defaults, delete the option to avoid conflicts
+	if (requestOptions.port === 80 || requestOptions.port === 443) {
+		delete requestOptions.port;
+	}	
 
 	// Add cookie header from cookie jar if we're configured to
 	// send/accept cookies


### PR DESCRIPTION
I was getting internal client errors because the Queue was being populated with port:80 queueItems but the protocol was listed as https. This caused a call to https.get({port:80}) which throws an OpenSSH error:

```
[Error: 140735148347776:error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol:../deps/openssl/openssl/ssl/s23_clnt.c:766:
```
