### PR TITLE
Spotted a typo in the readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -443,7 +443,7 @@ You'll probably often need to determine how many items in the queue have a given
 status at any one time, and/or retreive them. That's easy with
 `crawler.queue.countWithStatus` and `crawler.queue.getWithStatus`.
 
-`crawler.queue.getwithStatus` returns the number of queued items with a given
+`crawler.queue.countWithStatus` returns the number of queued items with a given
 status, while `crawler.queue.getWithStatus` returns an array of the queue items
 themselves.
 


### PR DESCRIPTION
"**`crawler.queue.getwithStatus`** returns the number of queued items with a given status, while `crawler.queue.getWithStatus` returns an array of the queue items themselves" doesn't make sense, I think you meant countWithStatus the first time.
