### PR TITLE
Avoid client overwrite Host Header on HTTP Request behind Proxy

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -693,7 +693,8 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
 		port: requestPort,
 		path: requestPath,
 		headers: {
-			"User-Agent": crawler.userAgent
+			"User-Agent": crawler.userAgent,
+            "Host" : queueItem.host
 		}
 	};
 	


### PR DESCRIPTION
Add Host header to the request. This fix an issues: If you have to use Http Proxy, this prevent overwrite Host header with proxy address instead of target address.
