### PR TITLE
Bugfix: get cookie from original host when use proxy

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -712,7 +712,7 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
 	// send/accept cookies
 	if (crawler.acceptCookies && crawler.cookies.getAsHeader()) {
 		requestOptions.headers.cookie =
-			crawler.cookies.getAsHeader(queueItem.host,queueItem.host);
+			crawler.cookies.getAsHeader(queueItem.host,queueItem.path);
 	}
 
 	// Add auth headers if we need them


### PR DESCRIPTION
The variable requestHost is proxy host when use proxy, but the cookie is on original host.
