### PR TITLE
Add config option to follow initial redirects to a different domain.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -249,6 +249,9 @@ Here's a complete list of what you can stuff with at this stage:
 	`Node/SimpleCrawler <version> (http://www.github.com/cgiffard/node-simplecrawler)`.
 *	`crawler.queue` -
 	The queue in use by the crawler (Must implement the `FetchQueue` interface)
+*   `crawler.allowInitialDomainChange` -
+    If the response for the initial url is a redirect to another domain, update `crawler.host` to
+    continue the crawling on that domain. Defaults to false.
 *	`crawler.filterByDomain` -
 	Specifies whether the crawler will restrict queued requests to a given
 	domain/domains.

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -76,6 +76,9 @@ var Crawler = function(host,initialPath,initialPort,interval) {
 	// (but it's basically just an array)
 	crawler.queue			= new FetchQueue();
 
+	// Should we update crawler.host if the first response is a redirect to another domain.
+	crawler.allowInitialDomainChange = false;
+
 	// Do we filter by domain?
 	// Unless you want to be crawling the entire internet, I would
 	// recommend leaving this on!
@@ -160,6 +163,7 @@ var Crawler = function(host,initialPath,initialPort,interval) {
 
 	// STATE (AND OTHER) VARIABLES NOT TO STUFF WITH
 	var hiddenProps = {
+		"_isFirstRequest":	true,
 		"_openRequests":	0,
 		"_fetchConditions":	[],
 		"_openListeners":	0
@@ -939,6 +943,7 @@ Crawler.prototype.handleResponse = function(queueItem,response,timeCommenced) {
 
 		response.on("data",receiveData);
 		response.on("end",receiveData);
+		crawler._isFirstRequest = false;
 
 	// We've got a not-modified response back
 	} else if (response.statusCode === 304) {
@@ -954,6 +959,8 @@ Crawler.prototype.handleResponse = function(queueItem,response,timeCommenced) {
 			crawler.emit("notmodified",queueItem,response);
 		}
 
+		crawler._isFirstRequest = false;
+
 	// If we should queue a redirect
 	} else if (response.statusCode >= 300 && response.statusCode < 400 &&
 					response.headers.location) {
@@ -966,6 +973,10 @@ Crawler.prototype.handleResponse = function(queueItem,response,timeCommenced) {
 
 		// Emit redirect event
 		crawler.emit("fetchredirect",queueItem,parsedURL,response);
+
+		if (crawler.allowInitialDomainChange && crawler._isFirstRequest) {
+			crawler.host = parsedURL.host;
+		}
 
 		// Clean URL, add to queue...
 		crawler.queueURL(parsedURL,queueItem);
@@ -982,6 +993,8 @@ Crawler.prototype.handleResponse = function(queueItem,response,timeCommenced) {
 
 		crawler._openRequests --;
 
+		crawler._isFirstRequest = false;
+
 	// And oh dear. Handle this one as well. (other 400s, 500s, etc)
 	} else {
 		queueItem.fetched = true;
@@ -991,6 +1004,8 @@ Crawler.prototype.handleResponse = function(queueItem,response,timeCommenced) {
 		crawler.emit("fetcherror",queueItem,response);
 
 		crawler._openRequests --;
+
+		crawler._isFirstRequest = false;
 	}
 
 	return crawler;


### PR DESCRIPTION
If crawler.allowInitialDomainChange is set to true, and the initial url redirects to a different domain (e.g. a .com redirects to a canonical .net domain), crawler.host is updated to the new domain, to allow crawling to continue on that domain.