### PR TITLE
Add maxDepth parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -106,6 +106,15 @@ myCrawler.interval = 10000; // Ten seconds
 myCrawler.maxConcurrency = 1;
 ```
 
+You can also define a max depth for links to fetch :
+```javascript
+myCrawler.maxDepth = 1; // Only first page is fetched (with linked CSS & images)
+// Or: 
+myCrawler.maxDepth = 2; // First page and discovered links from it are fetched
+// Or: 
+myCrawler.maxDepth = 3; // Etc.
+```
+
 For brevity, you may also specify the initial path and request interval when
 creating the crawler:
 

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -158,6 +158,9 @@ var Crawler = function(host,initialPath,initialPort,interval) {
 		/^javascript\:[a-z0-9\$\_\.]+\(['"][^'"\s]+/ig
 	];
 
+	// Max depth parameter
+	crawler.maxDepth = 0;
+
 	// STATE (AND OTHER) VARIABLES NOT TO STUFF WITH
 	var hiddenProps = {
 		"_openRequests":	0,
@@ -206,6 +209,7 @@ Crawler.prototype.start = function() {
 			crawler.host,
 			crawler.initialPort,
 			crawler.initialPath,
+			1,							// Initial depth
 			function(error) {
 				if (error) throw error;
 			});
@@ -283,6 +287,44 @@ Crawler.prototype.mimeTypeSupported = function(MIMEType) {
 };
 
 /*
+	Public: Determines whether the queueItem can be fetched from its depth
+
+	In fact, the queueItem need to be fetched before calling this (because we need its MIMEType).
+	This will just determine if we need to send an event for this item & if we need to fetch linked
+	resources.
+
+	If the queue item is a CSS or JS file, it will always be fetched (we need all images in CSS files,
+	even if max depth is already reached). If it's an HTML page, we will check if max depth is reached
+	or not.
+
+	queueItem	- Queue item object to check
+
+	Returns a boolean, true if the queue item can be fetched - false if not.
+
+*/
+Crawler.prototype.depthAllowed = function(queueItem) {
+	var crawler = this;
+
+	// Items matching this pattern will always be fetched, even if max depth is reached
+	var mimeTypesWhitelist = [
+		/^text\/(css|javascript|ecmascript)/i,
+		/^application\/javascript/i,
+		/^application\/x-font/i,
+		/^application\/font/i,
+		/^image\//i,
+		/^font\//i
+	];
+
+	return (
+		crawler.maxDepth === 0 ||
+		queueItem.depth <= crawler.maxDepth || 
+		mimeTypesWhitelist.reduce(function(prev,mimeCheck) {
+			return prev || !!mimeCheck.exec(queueItem.stateData.contentType);
+		}, false)
+	);
+};
+
+/*
 	Public: Extracts protocol, host, port and resource (path) given a URL string.
 
 	URL	- String containing URL to process
@@ -304,7 +346,8 @@ Crawler.prototype.processURL = function(URL,context) {
 				crawler.initialProtocol + "://" +
 				crawler.host + ":" +
 				crawler.initialPort + "/"
-			)
+			),
+			depth: 1
 		};
 
 	// If the URL didn't contain anything, don't fetch it.
@@ -335,7 +378,8 @@ Crawler.prototype.processURL = function(URL,context) {
 		"host":	newURL.hostname(),
 		"port":	newURL.port() || 80,
 		"path":	newURL.resource(),
-		"uriPath": newURL.path()
+		"uriPath": newURL.path(),
+		"depth": context.depth+1
 	};
 };
 
@@ -618,6 +662,7 @@ Crawler.prototype.queueURL = function(url,queueItem) {
 			parsedURL.host,
 			parsedURL.port,
 			parsedURL.path,
+			parsedURL.depth,
 			function queueAddCallback(error,newQueueItem) {
 				if (error) {
 					// We received an error condition when adding the callback
@@ -852,8 +897,6 @@ Crawler.prototype.handleResponse = function(queueItem,response,timeCommenced) {
 		stateData.actualDataSize	= responseBuffer.length;
 		stateData.sentIncorrectSize = responseBuffer.length !== responseLength;
 
-		crawler.emit("fetchcomplete",queueItem,responseBuffer,response);
-
 		// First, save item to cache (if we're using a cache!)
 		if (crawler.cache !== null &&
 			crawler.cache.setCacheData instanceof Function) {
@@ -861,10 +904,15 @@ Crawler.prototype.handleResponse = function(queueItem,response,timeCommenced) {
 			crawler.cache.setCacheData(queueItem,responseBuffer);
 		}
 
-		// We only process the item if it's of a valid mimetype
-		// and only if the crawler is set to discover its own resources
-		if (crawler.mimeTypeSupported(contentType) && crawler.discoverResources) {
-			crawler.queueLinkedItems(responseBuffer,queueItem);
+		// Is the item allowed by depth conditions ?
+		if(crawler.depthAllowed(queueItem)) {
+			crawler.emit("fetchcomplete",queueItem,responseBuffer,response);
+
+			// We only process the item if it's of a valid mimetype
+			// and only if the crawler is set to discover its own resources
+			if (crawler.mimeTypeSupported(contentType) && crawler.discoverResources) {
+				crawler.queueLinkedItems(responseBuffer,queueItem);
+			}
 		}
 
 		crawler._openRequests --;

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -23,7 +23,7 @@ var FetchQueue = function(){
 module.exports = FetchQueue;
 
 FetchQueue.prototype = [];
-FetchQueue.prototype.add = function(protocol,domain,port,path,callback) {
+FetchQueue.prototype.add = function(protocol,domain,port,path,depth,callback) {
 	callback = callback && callback instanceof Function ? callback : function(){};
 	var self = this;
 
@@ -47,6 +47,7 @@ FetchQueue.prototype.add = function(protocol,domain,port,path,callback) {
 					"host": domain,
 					"port": port,
 					"path": path,
+					"depth": depth,
 					"fetched": false,
 					"status": "queued",
 					"stateData": {}

--- a/test/depth.js
+++ b/test/depth.js
@@ -1,0 +1,68 @@
+// Runs a very simple crawl on an HTTP server with different depth
+
+var chai = require("chai");
+    chai.should();
+
+var testserver = require("./lib/testserver.js");
+
+var Crawler	= require("../");
+
+// Test the number of links discovered for the given "depth" and compare it to "linksToDiscover"
+var depthTest = function(depth, linksToDiscover) {
+	depth = parseInt(depth); // Force depth to be a number
+
+	var crawler;
+	var linksDiscovered;
+
+	describe("depth "+ depth, function() {
+		before(function() {
+			// Create a new crawler to crawl our local test server
+			crawler = new Crawler("127.0.0.1","/depth/1",3000);
+
+			// Speed up tests. No point waiting for every request when we're running
+			// our own server.
+			crawler.interval = 1;
+
+			// Define max depth for this crawl
+			crawler.maxDepth = depth;
+
+			linksDiscovered = 0;
+
+			crawler.on("fetchcomplete",function(queueItem) {
+				linksDiscovered++;
+			});
+
+			crawler.start();
+		});
+
+		after(function() {
+			// Clean listeners and crawler
+			crawler.removeAllListeners("discoverycomplete");
+			crawler.removeAllListeners("complete");
+			crawler = null;
+		});
+
+		it("should discover "+ linksToDiscover +" linked resources",function(done) {
+			crawler.on("complete",function() {
+				linksDiscovered.should.equal(linksToDiscover);
+				done();
+			});
+		});
+	});
+};
+
+describe("Crawler max depth",function() {
+
+	// depth: linksToDiscover
+	var linksToDiscover = {
+		0: 11, // links for depth 0
+		1: 6,  // links for depth 1
+		2: 7,  // links for depth 2
+		3: 11  // links for depth 3
+	};
+
+	for(var depth in linksToDiscover) {
+		depthTest(depth, linksToDiscover[depth]);
+	}
+
+});

--- a/test/lib/routes.js
+++ b/test/lib/routes.js
@@ -40,5 +40,50 @@ module.exports = {
 
 	"/timeout": function(write) {
 		// We want to trigger a timeout. Never respond.
+	},
+
+	// Routes for depth tests
+	"/depth/1": function(write) {
+		write(200,"<link rel='stylesheet' href='/css'> Home. <a href='/depth/2'>depth2</a>");
+	},
+
+	"/depth/2": function(write) {
+		write(200,"Depth 2. http://127.0.0.1:3000/depth/3");
+	},
+
+	"/depth/3": function(write) {
+		write(200,"Depth 3. <link rel='stylesheet' href='/css/2'> <link rel='stylesheet' href='/css/4'>");
+	},
+
+	"/css": function(write) {
+		write(200,"/* CSS 1 */ @import url('/css/2'); @font-face { url(/font/1) format('woff'); }", "text/css");
+	},
+
+	"/css/2": function(write) {
+		write(200,"/* CSS 2 */ @import url('/css/3'); .img1 { background-image:url('/img/1'); }", "text/css");
+	},
+
+	"/css/3": function(write) {
+		write(200,"/* CSS 3 */", "text/css");
+	},
+
+	"/css/4": function(write) {
+		write(200,"/* CSS 4 */ .img1 { background-image:url('/img/2'); } @font-face { url(/font/2) format('woff'); }", "text/css");
+	},
+
+	"/img/1": function(write) {
+		write(200,"", "image/png");
+	},
+
+	"/img/2": function(write) {
+		write(200,"", "image/png");
+	},
+
+	"/font/1": function(write) {
+		write(200,"", "font/woff");
+	},
+
+	"/font/2": function(write) {
+		write(200,"", "application/font-woff");
 	}
 };


### PR DESCRIPTION
- SimpleCrawler now support defining a max depth for links to fetch.
- CSS/JS files are not affected by depth. This way all images and linked CSS/JS files from allowed HTML pages are fetched. If the HTML page depth is greater than max depth, we will not fetch it and not discover resources on it.

Should fix #65 
