### PR TITLE
Add maxSameRedirects option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -313,6 +313,9 @@ Here's a complete list of what you can stuff with at this stage:
 *	`crawler.urlEncoding` -
 	Set this to `iso8859` to trigger URIjs' re-encoding of iso8859 URLs to unicode.
 	Defaults to `unicode`.
+*	`crawler.maxSameRedirects` -
+	Define the max redirects the crawler should follow to the same page.
+	Defaults to 0 (we don't follow redirects to the same page).
 
 #### Excluding certain resources from downloading
 

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -110,6 +110,12 @@ var Crawler = function(host,initialPath,initialPort,interval) {
 	crawler.acceptCookies	= true;
 	crawler.cookies			= new CookieJar();
 
+	// Max redirects to the same page we should follow
+	crawler.maxSameRedirects = 0;
+	
+	// URLs redirected and number of times it was
+	crawler.redirectedUrls = {};
+
 	// Support for custom headers...
 	crawler.customHeaders	= {};
 
@@ -964,6 +970,20 @@ Crawler.prototype.handleResponse = function(queueItem,response,timeCommenced) {
 		// Parse the redirect URL ready for adding to the queue...
 		parsedURL = crawler.processURL(response.headers.location,queueItem);
 
+		// Redirect to the same URL ? We should check for maxSameRedirects.
+		if(crawler.maxSameRedirects > 0 && crawler.sameURLs(queueItem, parsedURL)) {
+			if(queueItem.url in crawler.redirectedUrls) {
+				crawler.redirectedUrls[queueItem.url]++;
+			} else {
+				crawler.redirectedUrls[queueItem.url] = 1;
+			}
+
+			// If we have not reached max redirects, we should be able to add the URL to the queue again
+			if(crawler.redirectedUrls[queueItem.url] <= crawler.maxSameRedirects) {
+				crawler.queue.removeUrlFromIndex(queueItem.url);
+			}
+		}
+
 		// Emit redirect event
 		crawler.emit("fetchredirect",queueItem,parsedURL,response);
 
@@ -1163,5 +1183,19 @@ Crawler.prototype.removeQuerystring = function(url) {
 		return url;
 	}
 };
+
+/*
+	Public: Compare two URL objects to check if they are the same
+
+	url1 - First URL to compare
+	url2 - Second URL to compare
+
+	Returns true if the two URLs are the sames, false if they are not
+
+*/
+Crawler.prototype.sameURLs = function(url1, url2) {
+	return (url1.protocol == url2.protocol && url1.domain == url2.domain && url1.port == url2.port && url1.path == url2.path);
+};
+
 
 module.exports = Crawler;

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -297,3 +297,8 @@ FetchQueue.prototype.defrost = function(filename,callback) {
 		callback(null,self);
 	});
 };
+
+// Remove item from scanIndex
+FetchQueue.prototype.removeUrlFromIndex = function(url) {
+	delete this.scanIndex[url];
+};

--- a/test/lib/routes.js
+++ b/test/lib/routes.js
@@ -40,5 +40,10 @@ module.exports = {
 
 	"/timeout": function(write) {
 		// We want to trigger a timeout. Never respond.
+	},
+
+	// Test for max redirects
+	"/redir-loop": function(write,redir) {
+		redir("/redir-loop");
 	}
 };

--- a/test/redirects.js
+++ b/test/redirects.js
@@ -1,0 +1,66 @@
+// Runs a very simple crawl on an HTTP server with different depth
+
+var chai = require("chai");
+    chai.should();
+
+var testserver = require("./lib/testserver.js");
+
+var Crawler	= require("../");
+
+// Test the number of links fetched for the given "maxRedir" and compare it to "linksToFetch"
+var redirTest = function(maxRedir, linksToFetch) {
+	maxRedir = parseInt(maxRedir); // Force maxRedir to be a number
+
+	var crawler;
+	var linksFetched;
+
+	describe("maxSameRedirects "+ maxRedir, function() {
+		before(function() {
+			// Create a new crawler to crawl our local test server
+			crawler = new Crawler("127.0.0.1","/redir-loop",3000);
+
+			// Speed up tests. No point waiting for every request when we're running
+			// our own server.
+			crawler.interval = 1;
+
+			// Define max depth for this crawl
+			crawler.maxSameRedirects = maxRedir;
+
+			linksFetched = 0;
+
+			crawler.on("fetchheaders",function(queueItem) {
+				linksFetched++;
+			});
+
+			crawler.start();
+		});
+
+		after(function() {
+			// Clean listeners and crawler
+			crawler.removeAllListeners("fetchheaders");
+			crawler.removeAllListeners("complete");
+			crawler = null;
+		});
+
+		it("should fetch "+ linksToFetch +" resources",function(done) {
+			crawler.on("complete",function() {
+				linksFetched.should.equal(linksToFetch);
+				done();
+			});
+		});
+	});
+};
+
+describe("Crawler max same redirects",function() {
+
+	// maxRedir: linksToFetch
+	var linksToFetch = {
+		0: 1,
+		1: 2
+	};
+
+	for(var maxRedir in linksToFetch) {
+		redirTest(maxRedir, linksToFetch[maxRedir]);
+	}
+
+});


### PR DESCRIPTION
Now we can handle redirects to the same page with a limit (to avoid infinite loop). The default limit is 0 (we don't follow redirects to the same page).

Some websites redirect to the same page e.g. after defining some cookies. With this option we can follow the redirect but avoid infinite loops.