### PR TITLE
Replace ALL '&amp;'s in URLs with ampersands

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -375,7 +375,7 @@ Crawler.prototype.discoverResources = function(resourceData,queueItem) {
 				.replace(/^javascript\:[a-z0-9]+\(['"]/i,"")
 				.replace(/["'\)]$/i,"")
 				.replace(/^\/\//, queueItem.protocol + "://")
-				.replace(/\&amp;/i,"&")
+				.replace(/\&amp;/gi,"&")
 				.split("#")
 				.shift();
 	}

--- a/test/discovery.js
+++ b/test/discovery.js
@@ -49,4 +49,15 @@ describe("Crawler link discovery",function() {
 		links[1].should.equal("http://example.com/resource");
 		links[2].should.equal("thingo.com/test.html");
 	});
+
+	it("should replace all '&amp;'s with ampersands",function() {
+
+		var links =
+			discover("<a href='http://example.com/resource?with&amp;query=params&amp;and=entities'>");
+
+		links.should.be.an("array");
+		links.length.should.equal(2);
+		links[0].should.equal("http://example.com/resource?with&query=params&and=entities");
+		links[1].should.equal("http://example.com/resource");
+	});
 });


### PR DESCRIPTION
Fixes 3364a5047 correctly. Previously only the first '&amp;' got replaced.
