### PR TITLE
Parse options for skipping HTML comments & script tags

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -161,6 +161,9 @@ var Crawler = function(host,initialPath,initialPort,interval) {
 	// Whether to parse inside HTML comments
 	crawler.parseHTMLComments = true;
 
+	// Whether to parse inside script tags
+	crawler.parseScriptTags = true;
+
 	// STATE (AND OTHER) VARIABLES NOT TO STUFF WITH
 	var hiddenProps = {
 		"_openRequests":	0,
@@ -372,6 +375,10 @@ Crawler.prototype.discoverResources = function(resourceData,queueItem) {
 
 	if (!crawler.parseHTMLComments) {
 		resourceText = resourceText.replace(/<!--([\s\S]+?)-->/g, "");
+	}
+
+	if (!crawler.parseScriptTags) {
+		resourceText = resourceText.replace(/<script(.*?)>([\s\S]+?)<\/script>/gi, "");
 	}
 
 	function cleanURL(URL) {

--- a/test/discovery.js
+++ b/test/discovery.js
@@ -83,4 +83,21 @@ describe("Crawler link discovery",function() {
 		links.length.should.equal(1);
 		links[0].should.equal("google.com");
 	});
+
+	it("should ignore script tags with parseScriptTags = false",function() {
+
+		crawler.parseScriptTags = false;
+
+		var links =
+			discover("	<script>var a = \"<a href='http://example.com/oneline_script'></a>\";</script> \
+						<a href=google.com> \
+						<script type='text/javascript'> \
+						http://example.com/resource \
+						<a href=example.com> \
+						</SCRIPT>");
+
+		links.should.be.an("array");
+		links.length.should.equal(1);
+		links[0].should.equal("google.com");
+	});
 });


### PR DESCRIPTION
Some pages contain junk like

```
<!--<script>
var maincontent = "#main";
var exampleimg= "<img src=\"http://example.com/images/exampleimage.png\" style=\"position:absolute; top: 10px; right:-169px; z-index: 99;\"/>";
if($(window).width() > 1270){
        $(maincontent).append(exampleimg);
}
</script>-->
```

This leads to a problem where the &lt;img&gt; tag in the script (which itself is in a comment) gets parsed, but returns only '\' (%5C) because of the escaped quotation mark.

I propose adding parseHTMLComments and parseScriptTags options with non-breaking defaults (ie. true) to skip HTML comments and script tags if wanted.
