### PR TITLE
Added depth (thanks @leeroybrun) to queueItems

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -399,6 +399,7 @@ is expected to have:
 * `host` - The full domain/hostname of the resource
 * `port` - The port of the resource
 * `path` - The bit of the URL after the domain - includes the querystring.
+* `depth` - The depth of the current item, starts at 1
 * `fetched` - Has the request for this item been completed? You can monitor this as requests are processed.
 * `status` - The internal status of the item, always a string. This can be one of:
 	* `queued` - The resource is in the queue to be fetched, but nothing's happened to it yet.

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -206,6 +206,7 @@ Crawler.prototype.start = function() {
 			crawler.host,
 			crawler.initialPort,
 			crawler.initialPath,
+			1,                           // initial depth
 			function(error) {
 				if (error) throw error;
 			});
@@ -304,7 +305,8 @@ Crawler.prototype.processURL = function(URL,context) {
 				crawler.initialProtocol + "://" +
 				crawler.host + ":" +
 				crawler.initialPort + "/"
-			)
+			),
+			depth: 1
 		};
 
 	// If the URL didn't contain anything, don't fetch it.
@@ -335,7 +337,8 @@ Crawler.prototype.processURL = function(URL,context) {
 		"host":	newURL.hostname(),
 		"port":	newURL.port() || 80,
 		"path":	newURL.resource(),
-		"uriPath": newURL.path()
+		"uriPath": newURL.path(),
+		"depth": context.depth + 1
 	};
 };
 
@@ -618,6 +621,7 @@ Crawler.prototype.queueURL = function(url,queueItem) {
 			parsedURL.host,
 			parsedURL.port,
 			parsedURL.path,
+			parsedURL.depth,
 			function queueAddCallback(error,newQueueItem) {
 				if (error) {
 					// We received an error condition when adding the callback

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -23,7 +23,7 @@ var FetchQueue = function(){
 module.exports = FetchQueue;
 
 FetchQueue.prototype = [];
-FetchQueue.prototype.add = function(protocol,domain,port,path,callback) {
+FetchQueue.prototype.add = function(protocol,domain,port,path,depth,callback) {
 	callback = callback && callback instanceof Function ? callback : function(){};
 	var self = this;
 
@@ -47,6 +47,7 @@ FetchQueue.prototype.add = function(protocol,domain,port,path,callback) {
 					"host": domain,
 					"port": port,
 					"path": path,
+					"depth": depth,
 					"fetched": false,
 					"status": "queued",
 					"stateData": {}


### PR DESCRIPTION
Removed the `maxDepth` option from #77, but left the `depth` parameter on `queueItem` as the same can (and should) be accomplished by a `filterCondition` using said depth.

Thanks very much to @leeroybrun for the original PR - I'm not trying to mess with your code, I just don't need the same as you do.
