### PR TITLE
Referer undefined validation - in requestOptions

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -773,7 +773,7 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
 								":" + queueItem.port :
 								""
 							),
-			"Referer":		queueItem.referrer
+			"Referer":		queueItem.referrer || ''
 		}
 	};
 

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -772,10 +772,13 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
 							queueItem.port !== 80 ?
 								":" + queueItem.port :
 								""
-							),
-			"Referer":		queueItem.referrer || ''
+							)
 		}
 	};
+	
+	if (queueItem.referrer) {
+		requestOptions.headers.Referer = queueItem.referrer;
+	}
 
 	// If port is one of the HTTP/HTTPS defaults, delete the option to avoid conflicts
 	if (requestOptions.port === 80 || requestOptions.port === 443) {


### PR DESCRIPTION
If the referer is undefined in the requestOption headers, the plugin terminates with a crash. Tested in windows 7, 64 bit with nodejs 0.12.*. 

Added validation for the same.