### PR TITLE
Infinite crawler.crawl() processor

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -835,20 +835,30 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
 
 		clientRequest.end();
 
-		clientRequest.setTimeout(crawler.timeout, function() {
-			clientRequest.abort();
-			crawler.emit("fetchtimeout",queueItem,crawler.timeout);
-		});
+		clientRequest.setTimeout(crawler.timeout, function () {
+            if (crawler.running && !queueItem.fetched) {
+                crawler._openRequests--;
 
-		clientRequest.on("error",function(errorData) {
-			crawler._openRequests --;
+                queueItem.fetched = true;
+                queueItem.status = "timeout";
+                crawler.emit("fetchtimeout", queueItem, crawler.timeout);
+            }
 
-			// Emit 5xx / 4xx event
-			crawler.emit("fetchclienterror",queueItem,errorData);
-			queueItem.fetched = true;
-			queueItem.stateData.code = 599;
-			queueItem.status = "failed";
-		});
+
+            clientRequest.abort();
+        });
+
+        clientRequest.on("error", function (errorData) {
+            if (crawler.running && !queueItem.fetched) {
+                crawler._openRequests--;
+
+                // Emit 5xx / 4xx event
+                crawler.emit("fetchclienterror", queueItem, errorData);
+                queueItem.fetched = true;
+                queueItem.stateData.code = 599;
+                queueItem.status = "failed";
+            }
+        });
 
 		return crawler;
 	});


### PR DESCRIPTION
Test case: crawling of http://www.cetelem.fr/, all default settings

In some case _openRequests gets below zero value, and crawl() complete check never returns true.
After debug i think, that problem here fetchQueueItem() in clientRequest.on("error"). It decrease _openRequests, but have no check that queueItem alredy fetched. No such check also above - in  clientRequest.setTimeout(). 

I dont think, that it's a low level reason, but after adding such checks - problem for me was solved.

Also without this checks clientRequest.setTimeout() sometimes called even after crawler complete its work. 

What do you think about it?