### PR TITLE
Update Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
 node_js:
-  - "0.11"
   - "0.10"
+  - "0.12"
+  - "iojs"
+matrix:
+  fast_finish: true

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-# Simple web-crawler for node.js [![Build Status](https://travis-ci.org/cgiffard/node-simplecrawler.png?branch=master)](https://travis-ci.org/cgiffard/node-simplecrawler)
+# Simple web-crawler for node.js [![Build Status](https://travis-ci.org/cgiffard/node-simplecrawler.svg?branch=master)](https://travis-ci.org/cgiffard/node-simplecrawler)
 
 Simplecrawler is designed to provide the most basic possible API for crawling
 websites, while being as flexible and robust as possible. I wrote simplecrawler


### PR DESCRIPTION
Use node.js 0.12, 0.12 and io.js.

It seems node-simplecraweler has issues with node.js > 0.10  https://github.com/ChrisWren/grunt-link-checker/issues/12