### PR TITLE
Option to add query parameters to every request

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -271,6 +271,8 @@ Here's a complete list of what you can stuff with at this stage:
 	Or go even further and strip WWW subdomain from requests altogether!
 *	`crawler.stripQuerystring` -
 	Specify to strip querystring parameters from URLs. Defaults to false.
+*	`crawler.queryParams` -
+	An object containing key value pairs to append as query parameters to every request.
 *	`crawler.discoverResources` -
 	Use simplecrawler's internal resource discovery function. Defaults to true.
 	(switch it off if you'd prefer to discover and queue resources yourself!)

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -96,6 +96,9 @@ var Crawler = function(host,initialPath,initialPort,interval) {
 	// Internal cachestore
 	crawler.cache			= null;
 
+	// Query parameters appended to each request
+	crawler.queryParams		= {};
+
 	// Use an HTTP Proxy?
 	crawler.useProxy		= false;
 	crawler.proxyHostname	= "127.0.0.1";
@@ -749,9 +752,9 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
 	}
 
 	// Extract request options from queue;
-	var requestHost = queueItem.host,
-		requestPort = queueItem.port,
-		requestPath = queueItem.path;
+	var requestHost   = queueItem.host,
+		requestPort   = queueItem.port,
+		requestPath   = queueItem.path;
 
 	// Are we passing through an HTTP proxy?
 	if (crawler.useProxy) {
@@ -760,7 +763,28 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
 		requestPath = queueItem.url;
 	}
 
-	// Load in request options
+    // Do we have a required query parameter?
+    if (Object.keys(crawler.queryParams)) {
+        var querystring = "";
+
+        // check and see if we have existing query parameters in the url
+        if (!requestPath.match(/\?[a-z0-9]+=/i)) {
+            querystring = "?";
+        }
+
+        // iterate the queryParams object and build the querystring
+        Object.keys(crawler.queryParams).forEach(function(key) {
+            // if there exists a query string, "&" the key value pair on the end
+            if (querystring !== "?") {
+                querystring += "&";
+            }
+            querystring += key + "=" + crawler.queryParams[key];
+        });
+
+        requestPath += querystring;
+    }
+
+    // Load in request options
 	requestOptions = {
 		method:	"GET",
 		host:	requestHost,
@@ -775,7 +799,7 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
 							)
 		}
 	};
-	
+
 	if (queueItem.referrer) {
 		requestOptions.headers.Referer = queueItem.referrer;
 	}

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -752,9 +752,9 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
 	}
 
 	// Extract request options from queue;
-	var requestHost   = queueItem.host,
-		requestPort   = queueItem.port,
-		requestPath   = queueItem.path;
+	var requestHost = queueItem.host,
+		requestPort = queueItem.port,
+		requestPath = queueItem.path;
 
 	// Are we passing through an HTTP proxy?
 	if (crawler.useProxy) {

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -781,6 +781,7 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
             querystring += key + "=" + crawler.queryParams[key];
         });
 
+        // append the composed query string on to the request url
         requestPath += querystring;
     }
 


### PR DESCRIPTION
I needed the ability to send a query parameter along with any url my crawler requested from my server. In my case this crawler is used to generate a cache of prerendered pages for my angular application. By passing the refresh=true query parameter, I clear the cache for the requested url and save a new version of the page to the cache.

There was no way to supply query parameters with each request, so I have added it in this PR. The format is an object with key value pairs for each query parameter and its value.

If you would like any variable names changed  to fit convention let me know and I can change them. There is also no test for this. There is no test for the querystring strip either, so I didn't put one in for this. Let me know if you would like me to write one.