### PR TITLE
Ignore Depth Regex

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -295,6 +295,10 @@ Here's a complete list of what you can stuff with at this stage:
 
 *	`crawler.discoverRegex` -
 	Array of regex objects that simplecrawler uses to discover resources.
+*	`crawler.discoverNoDepthRegex` —
+	Array of regex objects that simplecrawler will explude from	`maxDepth`
+	checks (will not trigger if not set). Allows paginated posts etc to be
+	fetched in full.
 *	`crawler.cache` -
 	Specify a cache architecture to use when crawling. Must implement
 	`SimpleCache` interface. You can save the site to disk using the built in file

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -346,7 +346,7 @@ Crawler.prototype.depthAllowed = function(queueItem) {
 		crawler.maxDepth === 0 ||
 		queueItem.depth <= crawler.maxDepth ||
 		(
-			crawler.discoverNoDepthRegex.lenghth > 0 &&
+			crawler.discoverNoDepthRegex.length > 0 &&
 			crawler.discoverNoDepthRegex.reduce(function(prev,urlCheck) {
 				return prev || !!urlCheck.exec(queueItem.url);
 			}, false)

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -160,6 +160,10 @@ var Crawler = function(host,initialPath,initialPort,interval) {
 		/^javascript\:[a-z0-9\$\_\.]+\(['"][^'"\s]+/ig
 	];
 
+	// Regular expressions for URL items that should ignore maxDepth limit
+	// URL items matching these pattern will always be fetched, even if max depth
+	crawler.discoverNoDepthRegex = [];
+
 	// Whether to parse inside HTML comments
 	crawler.parseHTMLComments = true;
 
@@ -316,7 +320,8 @@ Crawler.prototype.mimeTypeSupported = function(MIMEType) {
 
 	If the queue item is a CSS or JS file, it will always be fetched (we need
 	all images in CSS files, even if max depth is already reached). If it's an
-	HTML page, we will check if max depth is reached or not.
+	HTML page, we will check if max depth is reached or not and whether the URL
+	matches any no depth regex that may have been set.
 
 		queueItem	- Queue item object to check
 
@@ -340,6 +345,12 @@ Crawler.prototype.depthAllowed = function(queueItem) {
 	return (
 		crawler.maxDepth === 0 ||
 		queueItem.depth <= crawler.maxDepth ||
+		(
+			crawler.discoverNoDepthRegex.lenghth > 0 &&
+			crawler.discoverNoDepthRegex.reduce(function(prev,urlCheck) {
+				return prev || !!urlCheck.exec(queueItem.url);
+			}, false)
+		) ||
 		(
 			crawler.fetchWhitelistedMimeTypesBelowMaxDepth &&
 			mimeTypesWhitelist.reduce(function(prev,mimeCheck) {

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -348,12 +348,14 @@ Crawler.prototype.depthAllowed = function(queueItem) {
 		(
 			crawler.discoverNoDepthRegex.length > 0 &&
 			crawler.discoverNoDepthRegex.reduce(function(prev,urlCheck) {
+				urlCheck.lastIndex = 0;
 				return prev || !!urlCheck.exec(queueItem.url);
 			}, false)
 		) ||
 		(
 			crawler.fetchWhitelistedMimeTypesBelowMaxDepth &&
 			mimeTypesWhitelist.reduce(function(prev,mimeCheck) {
+				mimeCheck.lastIndex = 0;
 				return prev || !!mimeCheck.exec(queueItem.stateData.contentType);
 			}, false)
 		)


### PR DESCRIPTION
I don't know if you want to fold this into the main repo but I don't see why not as it only adds and option and otherwise does not affect the repo. I've added an additional option to both the code base and docs that allows a user to specify a regex that, if matched by a `queueItem` will be crawled no matter but what the current depth.

I needed this for the project I was using the repo for since I had posts paginated across multiple pages where I wanted the crawler to explore and scrape all the pages. So, for instance, I have this option set to ignore depth on all requests that end with `?pg=` some number to ensure I get the entire article even if the first page is queued when depth is already at max.

Hope that makes sense and thanks for the amazing library!!!