### PR TITLE
filterByDomain check should only be checked when adding to queue

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -83,6 +83,12 @@ var Crawler = function(host,initialPath,initialPort,interval) {
 	// recommend leaving this on!
 	crawler.filterByDomain	= true;
 
+        //do we do want to do discovery on non valid host links?
+	//this enables us to go 1 level deep on outside host links but no further when
+	//used with filterByDomain=true
+	//leaving as false to retain previous functionality
+        crawler.discoveryOnlyOnValidHosts = false;
+
 	// Do we scan subdomains?
 	crawler.scanSubdomains	= false;
 
@@ -424,6 +430,11 @@ Crawler.prototype.processURL = function(URL,context) {
 
 */
 Crawler.prototype.discoverResources = function(resourceData,queueItem) {
+	//if we don't want to do discovery on non-valid hosts and this isn't coming from a valid host, bail out
+	if( !(this.discoveryOnlyOnValidHosts && this.domainValid(queueItem.host)) ) {
+		return [];
+	}
+
 	// Convert to UTF-8
 	// TODO: account for text-encoding.
 	var resources = [],

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -586,8 +586,7 @@ Crawler.prototype.domainValid = function(host) {
 				host.split("").reverse().join(""));
 	}
 
-			// If we're not filtering by domain, just return true.
-	return	(!crawler.filterByDomain	||
+        return  (
 			// Or if the domain is just the right one, return true.
 			(host === crawler.host)	||
 			// Or if we're ignoring WWW subdomains, and both domains,
@@ -702,8 +701,8 @@ Crawler.prototype.queueURL = function(url,queueItem) {
 		return false;
 	}
 
-	// Check the domain is valid before adding it to the queue
-	if (crawler.domainValid(parsedURL.host)) {
+	// Check the domain is valid before adding it to the queue unless we're not filteringByDomain
+        if ( !crawler.filterByDomain || crawler.domainValid(parsedURL.host) ) {
 		crawler.queue.add(
 			parsedURL.protocol,
 			parsedURL.host,


### PR DESCRIPTION
crawler.filterByDomain should only restrict what we add to the queue, not what is considered "valid". will suggest in another commit an additional configuration that controls whether we restrict discovery to valid hosts