### PR TITLE
Stall out on 404's fix

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -1066,7 +1066,6 @@ Crawler.prototype.handleResponse = function(queueItem,response,timeCommenced) {
 
 			response.on("data",receiveData);
 			response.on("end",receiveData);
-
 		} else {
 			response.socket.end();
 		}
@@ -1100,6 +1099,7 @@ Crawler.prototype.handleResponse = function(queueItem,response,timeCommenced) {
 
 		// Clean URL, add to queue...
 		crawler.queueURL(parsedURL,queueItem);
+		response.socket.end();
 
 		crawler._openRequests --;
 
@@ -1110,6 +1110,7 @@ Crawler.prototype.handleResponse = function(queueItem,response,timeCommenced) {
 
 		// Emit 404 event
 		crawler.emit("fetch404",queueItem,response);
+		response.socket.end();
 
 		crawler._openRequests --;
 
@@ -1120,6 +1121,7 @@ Crawler.prototype.handleResponse = function(queueItem,response,timeCommenced) {
 
 		// Emit 5xx / 4xx event
 		crawler.emit("fetcherror",queueItem,response);
+		response.socket.end();
 
 		crawler._openRequests --;
 	}


### PR DESCRIPTION
I was having issues where the crawler would stall out when I hit 404's or anything that wasn't a 200. By "stall out" I mean that the process.nextTick callback would not be called for a lengthy period of time with nothing else appearing to run. Adding socket.end() fixed it for some reason. Anyone know why? I couldn't find any documentation in node that explained what was going on. 