### PR TITLE
Correctly discover URLs that legitimately end with a quote or parenthesis

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -148,10 +148,14 @@ var Crawler = function(host,initialPath,initialPort,interval) {
 
 	// Regular expressions for finding URL items in HTML and text
 	crawler.discoverRegex = [
-		/(\shref\s?=\s?|\ssrc\s?=\s?|url\()([^\"\'\s>\)]+)/ig,
-		/(\shref\s?=\s?|\ssrc\s?=\s?|url\()['"]([^"']+)/ig,
+		/\s?(?:href|src)\s?=\s?(["']).*?\1/ig,
+		/\s?(?:href|src)\s?=\s?[^"'][^\s>]+/ig,
+		/\s?url\((["']).*?\1\)/ig,
+		/\s?url\([^"'].*?\)/ig,
+
+		// This could easily duplicate matches above, e.g. in the case of
+		// href="http://example.com"
 		/http(s)?\:\/\/[^?\s><\'\"]+/ig,
-		/url\([^\)]+/ig,
 
 		// This might be a bit of a gamble... but get hard-coded
 		// strings out of javacript: URLs. They're often popup-image
@@ -446,11 +450,12 @@ Crawler.prototype.discoverResources = function(resourceData,queueItem) {
 
 	function cleanURL(URL) {
 		return URL
-				.replace(/^(\s*href|\s*src)\s*=+\s*['"]?/i,"")
+				.replace(/^(?:\s*href|\s*src)\s*=+\s*/i,"")
 				.replace(/^\s*/,"")
-				.replace(/^url\(['"]*/i,"")
-				.replace(/^javascript\:\s*[a-z0-9]+\(['"]/i,"")
-				.replace(/["'\)]$/i,"")
+				.replace(/^url\((.*)\)/i,"$1")
+				.replace(/^javascript\:\s*[a-z0-9]+\((.*)/i,"$1")
+				.replace(/^(['"])(.*)\1$/,"$2")
+				.replace(/^\((.*)\)$/,"$1")
 				.replace(/^\/\//, queueItem.protocol + "://")
 				.replace(/\&amp;/gi,"&")
 				.split("#")

--- a/test/discovery.js
+++ b/test/discovery.js
@@ -111,7 +111,7 @@ describe("Crawler link discovery",function() {
 		links.should.be.an("array");
 		links.length.should.equal(3);
 		links[0].should.equal("example.com/resource?with%28parentheses%29");
-		links[1].should.equal("example.com/resource?with\"double quotes\"");
-		links[2].should.equal("example.com/resource?with'single quotes'");
+		links[1].should.equal("example.com/resource?with%22double+quotes%22");
+		links[2].should.equal("example.com/resource?with%27single+quotes%27");
 	});
 });

--- a/test/discovery.js
+++ b/test/discovery.js
@@ -100,4 +100,18 @@ describe("Crawler link discovery",function() {
 		links.length.should.equal(1);
 		links[0].should.equal("google.com");
 	});
+
+	it("should discover URLs legitimately ending with a quote or parenthesis",function() {
+
+		var links =
+			discover("<a href='example.com/resource?with(parentheses)'>\
+						<a href='example.com/resource?with\"double quotes\"'>\
+						<a href=\"example.com/resource?with'single quotes'\">");
+
+		links.should.be.an("array");
+		links.length.should.equal(3);
+		links[0].should.equal("example.com/resource?with%28parentheses%29");
+		links[1].should.equal("example.com/resource?with\"double quotes\"");
+		links[2].should.equal("example.com/resource?with'single quotes'");
+	});
 });


### PR DESCRIPTION
I discovered this problem while scraping a truly horrible site that was full or URLs of the form `"scripts/run.dll?12341:Project+(Year)"`.  This PR makes a two changes to address these types of URLs:

1. Change the `discoverRegex` list so that trailing quotes or parentheses are kept
2. Change the `cleanURL` function to correctly identify and extract trailing quotes or parentheses.

In the process, I noticed that `discoverRegex` might match the same URL multiple times.  I don't think this is necessarily an issue since duplicate queued items should be passed over, and parsing from the text is a bit of guesswork anyway.  However, I added a comment just to note it in case the issue ever comes up.