### PR TITLE
Expose cleanExpandResources method and trim discovered resources

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -426,6 +426,20 @@ Crawler.prototype.processURL = function(URL, context) {
     };
 };
 
+/*
+    Private: Perform string replace operations on a URL string. Eg. removes
+    HTML attribute fluff around actual URL, replaces leading "//" with
+    absolute protocol etc.
+
+    queueItem - Queue item corresponding to where the resource was found
+    URL       - String to be cleaned up
+
+    Examples
+
+        cleanURL({protocol: "http"}, "url('//example.com/about') ")
+
+    Returns a string.
+ */
 function cleanURL (queueItem, URL) {
     return URL
         .replace(/^(?:\s*href|\s*src)\s*=+\s*/i, "")
@@ -441,20 +455,20 @@ function cleanURL (queueItem, URL) {
         .split("#")
         .shift()
         .trim();
-};
+}
 
 /*
-	Public: Clean up a list of resources (normally provided by discoverResources).
-	Also expands URL's that are relative to the current page.
+    Public: Clean up a list of resources (normally provided by discoverResources).
+    Also expands URL's that are relative to the current page.
 
-	urlMatch		- Array of string resources
-	queueItem		- Queue item corresponding to where the resources were retrieved from
+    urlMatch  - Array of string resources
+    queueItem - Queue item corresponding to where the resources were retrieved from
 
-	Examples
+    Examples
 
-		crawler.cleanExpandResources(["http://www.google.com", "/about", "mailto: example@example.com"])
+        crawler.cleanExpandResources(["http://www.google.com", "/about", "mailto: example@example.com"])
 
-	Returns an array of URL strings.
+    Returns an array of URL strings.
 */
 Crawler.prototype.cleanExpandResources = function (urlMatch, queueItem) {
     var crawler = this,

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -479,7 +479,7 @@ Crawler.prototype.cleanExpandResources = function (urlMatch, queueItem) {
                 return list;
             }
 
-            // If we hit an empty item, don't add return it
+            // If we hit an empty item, don't return it
             if (!URL.length) {
                 return list;
             }

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -387,7 +387,7 @@ Crawler.prototype.processURL = function(URL, context) {
     }
 
     // If the URL didn't contain anything, don't fetch it.
-    if (!URL.replace(/\s+/ig, "").length) {
+    if (!(URL && URL.replace(/\s+/ig,"").length)) {
         return false;
     }
 
@@ -426,6 +426,77 @@ Crawler.prototype.processURL = function(URL, context) {
     };
 };
 
+function cleanURL (queueItem, URL) {
+    return URL
+        .replace(/^(\s*href|\s*src)\s*=+\s*['"]?/i,"")
+        .replace(/^\s*/,"")
+        .replace(/^url\(['"]*/i,"")
+        .replace(/^javascript\:\s*[a-z0-9]+\(['"]/i,"")
+        .replace(/["'\)]$/i,"")
+        .replace(/^\/\//, queueItem.protocol + "://")
+        .replace(/\&amp;/gi,"&")
+        .split("#")
+        .shift()
+        .trim();
+};
+
+/*
+	Public: Clean up a list of resources (normally provided by discoverResources).
+	Also expands URL's that are relative to the current page.
+
+	urlMatch		- Array of string resources
+	queueItem		- Queue item corresponding to where the resources were retrieved from
+
+	Examples
+
+		crawler.cleanExpandResources(["http://www.google.com", "/about", "mailto: example@example.com"])
+
+	Returns an array of URL strings.
+*/
+Crawler.prototype.cleanExpandResources = function (urlMatch, queueItem) {
+    var crawler = this,
+        resources = [];
+
+    if (!urlMatch) {
+        return [];
+    }
+
+    return urlMatch
+        .map(cleanURL.bind(this, queueItem))
+        .reduce(function(list, URL) {
+
+            // Ensure URL is whole and complete
+            try {
+                URL = URI(URL)
+                    .absoluteTo(queueItem.url)
+                    .normalize()
+                    .toString();
+            } catch (e) {
+                // But if URI.js couldn't parse it - nobody can!
+                return list;
+            }
+
+            // If we hit an empty item, don't add return it
+            if (!URL.length) {
+                return list;
+            }
+
+            // If we don't support the protocol in question
+            if (!crawler.protocolSupported(URL)) {
+                return list;
+            }
+
+            // Does the item already exist in the list?
+            if (resources.reduce(function(prev, current) {
+                    return prev || current === URL;
+                }, false)) {
+                    return list;
+                }
+
+			return list.concat(URL);
+		}, []);
+};
+
 /*
     Public: Discovers linked resources in an HTML, XML or text document.
 
@@ -444,8 +515,7 @@ Crawler.prototype.processURL = function(URL, context) {
 Crawler.prototype.discoverResources = function(resourceData, queueItem) {
     // Convert to UTF-8
     // TODO: account for text-encoding.
-    var resources = [],
-        resourceText = resourceData.toString("utf8"),
+    var resourceText = resourceData.toString("utf8"),
         crawler = this;
 
     if (!queueItem) {
@@ -464,80 +534,12 @@ Crawler.prototype.discoverResources = function(resourceData, queueItem) {
         resourceText = resourceText.replace(/<script(.*?)>([\s\S]+?)<\/script>/gi, "");
     }
 
-    function cleanURL(URL) {
-        return URL
-                .replace(/^(?:\s*href|\s*src)\s*=+\s*/i, "")
-                .replace(/^\s*/, "")
-                .replace(/^url\((.*)\)/i, "$1")
-                .replace(/^javascript\:\s*[a-z0-9]+\((.*)/i, "$1")
-                .replace(/^(['"])(.*)\1$/, "$2")
-                .replace(/^\((.*)\)$/, "$1")
-                .replace(/^\/\//, queueItem.protocol + "://")
-                .replace(/\&amp;/gi, "&")
-                .replace(/\&#38;/gi, "&")
-                .replace(/\&#x00026;/gi, "&")
-                .split("#")
-                .shift();
-    }
-
-    // Clean links
-    function cleanAndQueue(urlMatch) {
-        if (!urlMatch) {
-            return [];
-        }
-
-        return urlMatch
-            .map(cleanURL)
-            .reduce(function(list, URL) {
-                var tmpURL;
-
-                // Ensure URL is whole and complete
-                try {
-                    tmpURL = URI(URL);
-
-                    if (queueItem.url) {
-                        URL = tmpURL
-                                .absoluteTo(queueItem.url)
-                                .normalize()
-                                .toString();
-                    } else {
-                        URL = tmpURL
-                            .normalize()
-                            .toString();
-                    }
-
-                } catch (e) {
-                    // But if URI.js couldn't parse it - nobody can!
-                    return list;
-                }
-
-                // If we hit an empty item, don't add return it
-                if (!URL.length) {
-                    return list;
-                }
-
-                // If we don't support the protocol in question
-                if (!crawler.protocolSupported(URL)) {
-                    return list;
-                }
-
-                // Does the item already exist in the list?
-                if (resources.reduce(function(prev, current) {
-                        return prev || current === URL;
-                    }, false)) {
-                        return list;
-                    }
-
-                return list.concat(URL);
-            }, []);
-    }
-
     // Rough scan for URLs
     return crawler.discoverRegex
         .reduce(function(list, regex) {
             return list.concat(
-                cleanAndQueue(
-                    resourceText.match(regex)));
+                crawler.cleanExpandResources(
+                    resourceText.match(regex), queueItem));
         }, [])
         .reduce(function(list, check) {
             if (list.indexOf(check) < 0) {

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -428,13 +428,16 @@ Crawler.prototype.processURL = function(URL, context) {
 
 function cleanURL (queueItem, URL) {
     return URL
-        .replace(/^(\s*href|\s*src)\s*=+\s*['"]?/i,"")
-        .replace(/^\s*/,"")
-        .replace(/^url\(['"]*/i,"")
-        .replace(/^javascript\:\s*[a-z0-9]+\(['"]/i,"")
-        .replace(/["'\)]$/i,"")
+        .replace(/^(?:\s*href|\s*src)\s*=+\s*/i, "")
+        .replace(/^\s*/, "")
+        .replace(/^url\((.*)\)/i, "$1")
+        .replace(/^javascript\:\s*[a-z0-9]+\((.*)/i, "$1")
+        .replace(/^(['"])(.*)\1$/, "$2")
+        .replace(/^\((.*)\)$/, "$1")
         .replace(/^\/\//, queueItem.protocol + "://")
-        .replace(/\&amp;/gi,"&")
+        .replace(/\&amp;/gi, "&")
+        .replace(/\&#38;/gi, "&")
+        .replace(/\&#x00026;/gi, "&")
         .split("#")
         .shift()
         .trim();
@@ -468,7 +471,7 @@ Crawler.prototype.cleanExpandResources = function (urlMatch, queueItem) {
             // Ensure URL is whole and complete
             try {
                 URL = URI(URL)
-                    .absoluteTo(queueItem.url)
+                    .absoluteTo(queueItem.url || "")
                     .normalize()
                     .toString();
             } catch (e) {


### PR DESCRIPTION
In some scenarios, developers might want to provice custom logic for extracting links, but still make use of simplecrawler's internal logic for cleaning and fixing up those links (eg. if you have a DOM parser library and only want to extract links from the href attributes of links). With this change you can call `crawler.cleanExpandResources` to do that!

Also now trimming all discovered resources, since URL's can't actually contain spaces and browsers etc. will ignore any spaces in href attributes.