### PR TITLE
Added robots.txt parser example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -401,6 +401,15 @@ from the crawler:
 myCrawler.removeFetchCondition(conditionID);
 ```
 
+##### Excluding resources based on robots.txt
+
+Simplecrawler [purposely](https://github.com/cgiffard/node-simplecrawler/issues/153)
+doesn't come with any built in support for parsing robots.txt rules. Adding
+support manually is very straightforward using fetch conditions however, and
+in `examples/robots-txt-example.js` you'll find an example that makes use of
+the [robots-parser](https://www.npmjs.com/package/robots-parser) module to do
+just that.
+
 ### The Simplecrawler Queue
 
 Simplecrawler has a queue like any other web crawler. It can be directly accessed

--- a/example/robots-txt-example.js
+++ b/example/robots-txt-example.js
@@ -1,0 +1,38 @@
+// Example of how to add a fetch condition to respect the rules of a robots.txt file
+
+var request = require("request"),
+	url = require("url"),
+	Crawler = require("../"),
+	parseRobots = require("robots-parser");
+
+
+
+var crawler =  new Crawler("example.com"),
+	robotsUrl = "http://example.com/robots.txt";
+
+request(robotsUrl, function (res, body) {
+	var robots = parseRobots(robotsUrl, body);
+
+	crawler.addFetchCondition(function (parsedUrl) {
+		var standardUrl = url.format({
+			protocol: parsedUrl.protocol,
+			host: parsedUrl.host,
+			pathname: parsedUrl.path.split("?")[0],
+			search: parsedUrl.path.split("?")[1]
+		});
+
+		var allowed = false;
+
+		// The punycode module sometimes chokes on really weird domain
+		// names. Catching those errors to prevent the crawler from crashing
+		try {
+			allowed = robots.isAllowed(standardUrl, crawler.userAgent);
+		} catch (error) {
+			console.error("Caught error from robots.isAllowed method on url %s", standardUrl, error);
+		}
+
+		return allowed;
+	});
+
+	crawler.start();
+});


### PR DESCRIPTION
By popular demand (#153) , I added an example to show how to integrate simplecrawler with robots-parser, a module that can parse robots.txt files and query URL's against the rules in them.