### PR TITLE
Decrement _openRequests when mimetype isn't supported

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -1124,7 +1124,9 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
             response.on("data", receiveData);
             response.on("end", receiveData);
         } else {
+            queueItem.fetched = true;
             crawler._openRequests--;
+
             response.socket.end();
         }
 

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -1124,6 +1124,7 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
             response.on("data", receiveData);
             response.on("end", receiveData);
         } else {
+            crawler._openRequests--;
             response.socket.end();
         }
 

--- a/test/reliability.js
+++ b/test/reliability.js
@@ -48,6 +48,22 @@ describe("Crawler reliability", function() {
         });
     });
 
+    it("should decrement _openRequests in the event of a non-supported mimetype", function(done) {
+
+        var localCrawler = new Crawler("127.0.0.1", "/", 3000);
+        localCrawler.downloadUnsupported = false;
+
+        localCrawler.queueURL("http://127.0.0.1:3000/img/1");
+        localCrawler.queueURL("http://127.0.0.1:3000/img/2");
+
+        localCrawler.on("complete", function() {
+            localCrawler._openRequests.should.equal(0);
+            done();
+        });
+
+        localCrawler.start();
+    });
+
     it("should emit a fetch404 when given a 410 status code", function(done) {
 
         this.slow("1s");


### PR DESCRIPTION
Fixes #144. Big problem, small solution. The indefinite hangup of the crawler was due to the fact that I had flipped downloadUnsupported to false (and this problem was triggered in that case).