### PR TITLE
Prevent timeout events from being emitted when item is already fetched

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -918,6 +918,10 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
         clientRequest.end();
 
         clientRequest.setTimeout(crawler.timeout, function() {
+            if (queueItem.fetched) {
+                return;
+            }
+
             if (crawler.running && !queueItem.fetched) {
                 crawler._openRequests--;
             }


### PR DESCRIPTION
Fixes #136. It was possible for timeout events to be emitted after a page had already emitted a 404 event. The reason for this is likely the fact that when 404's are handled, the HTTP response socket is closed, but the request socket isn't. I'm not too familiar with the node http api, but I'm guessing this is why the timeout event for that request can still be emitted.

Just like @fantapop thought, this was likely introduced in 40a71c1c5abffc2729316f4a90a0cb70b056612f, and this change makes simplecrawler behave the way it did before that commit.

Perhaps what's really needed here is for the request socket to be closed together with the response socket (once again, I haven't worked much with the node `http` module directly), but this fixes the problem until further notice anyway.