### PR TITLE
Throw error when testing if port 3000 is already in use

### DIFF
--- a/test/lib/testserver.js
+++ b/test/lib/testserver.js
@@ -55,6 +55,11 @@ httpServer.on("request", function(req, res) {
     }
 });
 
+httpServer.on("error", function (error) {
+    console.log(error);
+    process.exit(1);
+});
+
 httpServer.listen(3000);
 
 module.exports = httpServer;


### PR DESCRIPTION
I ran into a problem when running the test suite, where I was
already running a totally separate server on port 3000, which
caused the tests to bork out completely, without any clue as to
what the cause could be.

Even if it isn't meant to be feature rich, I thought it would be a
good idea to fail loudly if we can't start the testing http server
properly.