### PR TITLE
Fix URIjs package name

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -14,7 +14,7 @@ var FetchQueue      = require("./queue.js"),
 var http            = require("http"),
     https           = require("https"),
     EventEmitter    = require("events").EventEmitter,
-    uri             = require("URIjs"),
+    uri             = require("urijs"),
     zlib            = require("zlib"),
     util            = require("util");
 

--- a/lib/quickcrawl.js
+++ b/lib/quickcrawl.js
@@ -7,7 +7,7 @@
  */
 
 var Crawler = require("./crawler.js"),
-    uri     = require("URIjs");
+    uri     = require("urijs");
 
 
 /*

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "chai": "^3.2.0",
-    "eslint": "^1.4.3",
+    "eslint": "~1.4.3",
     "mocha": "^2.3.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplecrawler",
-  "description": "Very straigntforward web crawler. Uses EventEmitter. Generates queue statistics and has a basic cache mechanism with extensible backend.",
+  "description": "Very straightforward web crawler. Uses EventEmitter. Generates queue statistics and has a basic cache mechanism with extensible backend.",
   "version": "0.5.3",
   "homepage": "https://github.com/cgiffard/node-simplecrawler",
   "author": "Christopher Giffard <christopher.giffard@cgiffard.com>",
@@ -31,7 +31,7 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
-    "URIjs": "^1.16.0"
+    "urijs": "^1.16.1"
   },
   "devDependencies": {
     "chai": "^3.2.0",


### PR DESCRIPTION
URIjs authors renamed the package in the npm registry to urijs (all lowercase), and npm warns about this when installing URIjs. So I changed the name of the package in package.json