### PR TITLE
Better cleaning of "javascript:" href's

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -440,8 +440,9 @@ function cleanURL (queueItem, URL) {
     return URL
         .replace(/^(?:\s*href|\s*src)\s*=+\s*/i, "")
         .replace(/^\s*/, "")
+        .replace(/^(['"])(.*)\1$/, "$2")
         .replace(/^url\((.*)\)/i, "$1")
-        .replace(/^javascript\:\s*([a-z0-9]*\((.*)\))*.*/i, "$2")
+        .replace(/^javascript\:\s*([a-z0-9]*\(["'](.*)["']\))*.*/i, "$2")
         .replace(/^(['"])(.*)\1$/, "$2")
         .replace(/^\((.*)\)$/, "$1")
         .replace(/^\/\//, queueItem.protocol + "://")

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -441,7 +441,7 @@ function cleanURL (queueItem, URL) {
         .replace(/^(?:\s*href|\s*src)\s*=+\s*/i, "")
         .replace(/^\s*/, "")
         .replace(/^url\((.*)\)/i, "$1")
-        .replace(/^javascript\:\s*[a-z0-9]+\((.*)/i, "$1")
+        .replace(/^javascript\:\s*([a-z0-9]*\((.*)\))*.*/i, "$2")
         .replace(/^(['"])(.*)\1$/, "$2")
         .replace(/^\((.*)\)$/, "$1")
         .replace(/^\/\//, queueItem.protocol + "://")

--- a/test/discovery.js
+++ b/test/discovery.js
@@ -128,4 +128,19 @@ describe("Crawler link discovery", function() {
         links[1].should.equal("example.com/resource?with%22double+quotes%22");
         links[2].should.equal("example.com/resource?with%27single+quotes%27");
     });
+
+    it("should discard 'javascript:' links except for any arguments in there passed to functions", function () {
+
+        var links =
+            discover("<a href='javascript:;'>" +
+                     " <a href='javascript: void(0);'>" +
+                     " <a href='javascript: goToURL(\"/page/one\")'>", {
+                         url: "http://example.com/"
+                     });
+
+        links.should.be.an("array");
+        links.length.should.equal(2);
+        links[0].should.equal("http://example.com/");
+        links[1].should.equal("http://example.com/page/one");
+    });
 });


### PR DESCRIPTION
They may or may not contain function calls, and since it's a browser protocol, we can safely assume that all content in the href is javascript, so always make sure to replace all of it, only optionally retaining the arguments to any function call.

My issue was that some `"javascript:;"` href's returned `";"`, which is obviously wrong.

I'm almost wondering if it wouldn't be a better idea just to skip trying to retain parts of a `javascript:` href and instead just drop it altogether. It seems unlikely that the argument to any function in there would be a URL?