### PR TITLE
Avoid error by not trying to mkdir on filepath. Fixes #175

### DIFF
--- a/lib/cache-backend-fs.js
+++ b/lib/cache-backend-fs.js
@@ -200,7 +200,9 @@ FSBackend.prototype.setItem = function(queueObject, data, callback) {
                 // Write the file data in
                 writeFileData(currentPath, data);
             }
-            fs.mkdirSync(currentPath);
+            else{
+                fs.mkdirSync(currentPath);
+            }
 
         }
     });


### PR DESCRIPTION
This error is due to fs.mkdirSync is run on the filepath. 

This fix makes the cache be created but I didn't notice much of a performance benefit when running and re-running on a slow site with cache on. So perhaps the cache logic needs some work?