### PR TITLE
Prevent timeout events from stop crawler

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -918,8 +918,8 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
 
         clientRequest.end();
 
-        clientRequest.setTimeout(crawler.timeout, function() {
-            if (queueItem.fetched) {
+        clientRequest.setTimeout(crawler.timeout, function () {
+            if (clientRequest._crawlerHandled) {
                 return;
             }
 
@@ -927,9 +927,12 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
                 crawler._openRequests--;
             }
 
-            queueItem.fetched = true;
-            queueItem.status = "timeout";
-            crawler.emit("fetchtimeout", queueItem, crawler.timeout);
+            if (!queueItem.fetched) {
+                queueItem.fetched = true;
+                queueItem.status = "timeout";
+                crawler.emit("fetchtimeout", queueItem, crawler.timeout);
+            }
+
             clientRequest._crawlerHandled = true;
             clientRequest.abort();
         });


### PR DESCRIPTION
Hello, after commit from this request https://github.com/cgiffard/node-simplecrawler/pull/170 I found another problem with node 4.1.2 in clientRequest.setTimeout(crawler.timeout, function() {...});

In my test case when some redirects happen one by one socket already die, but clientRequest is still alive and when timeout event fired queueItem.fetched == true and we can't proceed to clientRequest.abort(); and crawl stoppes forever because _openRequests == maxConcurrency.
I've modified code to check clientRequest._crawlerHandled instead of queueItem.fetched and everything works fine on several projects

Here is example of problem project logs:
I've run project http://www.swannetoscar.com with maxConcurrency = 5
After 5 redirects _openrequest become 5 too and stoppes forevever
Fetch redirect: http://www.swannetoscar.com/factory/shirt/index/collar_product_id/918/ to http://www.swannetoscar.com/factory/shirt/#collar
Fetch redirect: http://www.swannetoscar.com/factory/shirt/index/collar_product_id/917/ to http://www.swannetoscar.com/factory/shirt/#collar
Fetch redirect: http://www.swannetoscar.com/factory/shirt/index/collar_product_id/919/ to http://www.swannetoscar.com/factory/shirt/#collar
Fetch redirect: http://www.swannetoscar.com/factory/shirt/index/collar_product_id/915/ to http://www.swannetoscar.com/factory/shirt/#collar
Fetch redirect: http://www.swannetoscar.com/factory/shirt/index/collar_product_id/916/ to http://www.swannetoscar.com/factory/shirt/#collar