### PR TITLE
Customizable agent for http / https.

### DIFF
--- a/example/socks-example.js
+++ b/example/socks-example.js
@@ -1,0 +1,33 @@
+var Crawler = require("../");
+var socks   = require("socksv5");
+
+var socksAuthNone = socks.auth.None;
+
+var socksSettings = {
+    proxyHost: "localhost",
+    proxyPort: 9050,
+    auths: [ socksAuthNone() ]
+};
+
+var crawler = new Crawler("icanhazip.com", "/", 80, null);
+
+crawler.httpAgent = new socks.HttpAgent(socksSettings);
+crawler.httpsAgent = new socks.HttpsAgent(socksSettings);
+
+crawler.on("crawlstart", function() {
+    console.log("Crawl starting");
+});
+
+crawler.on("fetchstart", function(queueItem) {
+    console.log("fetchStart", queueItem);
+});
+
+crawler.on("fetchcomplete", function(queueItem) {
+    console.log("fetchcomplete", queueItem);
+});
+
+crawler.on("complete", function() {
+    console.log("Finished!");
+});
+
+crawler.start();

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -187,6 +187,10 @@ var Crawler = function(host, initialPath, initialPort, interval) {
     // Ignore invalid SSL certificates
     crawler.ignoreInvalidSSL = false;
 
+    // The HTTP / HTTPS agent used to crawl
+    crawler.httpAgent       = http.globalAgent;
+    crawler.httpsAgent      = https.globalAgent;
+
     // STATE (AND OTHER) VARIABLES NOT TO STUFF WITH
     var hiddenProps = {
         _openRequests: 0,
@@ -822,10 +826,11 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
     // Mark as spooled
     queueItem.status = "spooled";
     var client = queueItem.protocol === "https" ? https : http;
+    var agent  = queueItem.protocol === "https" ? crawler.httpsAgent : crawler.httpAgent;
 
     // Up the socket limit if required.
-    if (client.globalAgent.maxSockets < crawler.maxConcurrency) {
-        client.globalAgent.maxSockets = crawler.maxConcurrency;
+    if (agent.maxSockets < crawler.maxConcurrency) {
+        agent.maxSockets = crawler.maxConcurrency;
     }
 
     // Extract request options from queue;
@@ -846,6 +851,7 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
         host:   requestHost,
         port:   requestPort,
         path:   requestPath,
+        agent:  agent,
         headers: {
             "User-Agent":   crawler.userAgent,
             "Host":         queueItem.host + (


### PR DESCRIPTION
Also adds a quick SOCKS proxy example (requires the `socksv5` package)

I wasn't sure what the best way to test this was, so I'm open to suggestions. If creating a dummy agent that does nothing is non-trivial (node noob here), that might be an option.