### PR TITLE
fix: determine port correctly for HTTPs resources

### DIFF
--- a/lib/quickcrawl.js
+++ b/lib/quickcrawl.js
@@ -63,7 +63,7 @@ module.exports = function crawl(url, successCallback, failCallback) {
         throw new Error("Can't crawl with unspecified path.");
     }
 
-    var tmpCrawler = new Crawler(url.hostname(), url.path(), url.port() || 80);
+    var tmpCrawler = new Crawler(url.hostname(), url.path(), url.port() || (url.protocol() === "https" ? 443 : 80));
 
     // Attach callbacks if they were provided
     if (successCallback) {


### PR DESCRIPTION
Currently when using an HTTPs URL without explicitly specifying the port, the default port is incorrectly determined to be `80` when it should be `443`.