### PR TITLE
Always match cookies with a wild card domain

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -437,6 +437,10 @@ Cookie.prototype.isExpired = function() {
 
 */
 Cookie.prototype.matchDomain = function(domain) {
+    if (this.domain === "*") {
+        return true;
+    }
+
     var reverseDomain = this.domain.split("").reverse().join(""),
         reverseDomainComp = domain.split("").reverse().join("");
 


### PR DESCRIPTION
Cookies instantiated without a domain get their domain property set
to "*" by default, which seems to imply that they should match any
domain, but matchDomain() did not treat them as such.

* Change matchDomain() to return true for cookies with domain of "*"