### PR TITLE
Make sure response sockets are always destroyed

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -1165,7 +1165,7 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
             queueItem.fetched = true;
             crawler._openRequests--;
 
-            response.socket.end();
+            response.socket.destroy();
         }
 
     // We've got a not-modified response back
@@ -1219,7 +1219,7 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
 
         // Emit 5xx / 4xx event
         crawler.emit("fetcherror", queueItem, response);
-        response.socket.end();
+        response.socket.destroy();
 
         crawler._openRequests--;
     }


### PR DESCRIPTION
When simplecrawler encounters a lot of URL's that are rejected because of their `Content-Type`, it starts generating DNS errors after a while (`getaddrinfo EMFILE`). It seems this error can arise when a node.js application uses too many sockets ([bug report](https://github.com/nodejs/node-v0.x-archive/issues/7729)). I suspect that simplecrawler is triggering this error by just calling the `end` method on the http response socket, as this might leave the socket open until all data has been received. The problem of sockets not closing in a timely fashion is likely magnified when dealing with resources that might be rejected because of their `Content-Type` - images etc - since they usually are larger than text resources.

Calling the `destroy` method instead of `end` on the sockets when the content-type is denied prevents simplecrawler from leaking resources.