### PR TITLE
New behavior for closing requests

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -1050,9 +1050,12 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
 
     // Function for dealing with 200 responses
     function processReceivedData() {
-        if (queueItem.fetched) {
+        if (dataReceived || queueItem.fetched) {
             return;
         }
+
+        responseBuffer = responseBuffer.slice(0, responseLengthReceived);
+        dataReceived = true;
 
         timeDataReceived = new Date().getTime();
 
@@ -1088,60 +1091,52 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
     }
 
     function receiveData(chunk) {
-        if (chunk && chunk.length && !dataReceived) {
-            if (responseLengthReceived + chunk.length > responseBuffer.length) {
-                // Oh dear. We've been sent more data than we were initially told.
-                // This could be a mis-calculation, or a streaming resource.
-                // Let's increase the size of our buffer to match, as long as it isn't
-                // larger than our maximum resource size.
+        if (!chunk.length || dataReceived) {
+            return;
+        }
 
-                if (responseLengthReceived + chunk.length <= crawler.maxResourceSize) {
+        if (responseLengthReceived + chunk.length > responseBuffer.length) {
+            // Oh dear. We've been sent more data than we were initially told.
+            // This could be a mis-calculation, or a streaming resource.
+            // Let's increase the size of our buffer to match, as long as it isn't
+            // larger than our maximum resource size.
 
-                    // Start by creating a new buffer, which will be our main
-                    // buffer from now on...
+            if (responseLengthReceived + chunk.length <= crawler.maxResourceSize) {
 
-                    var tmpNewBuffer = new Buffer(responseLengthReceived + chunk.length);
+                // Start by creating a new buffer, which will be our main
+                // buffer from now on...
 
-                    // Copy all our old data into it...
-                    responseBuffer.copy(tmpNewBuffer, 0, 0, responseBuffer.length);
+                var tmpNewBuffer = new Buffer(responseLengthReceived + chunk.length);
 
-                    // And now the new chunk
-                    chunk.copy(tmpNewBuffer, responseBuffer.length, 0, chunk.length);
+                // Copy all our old data into it...
+                responseBuffer.copy(tmpNewBuffer, 0, 0, responseBuffer.length);
 
-                    // And now make the response buffer our new buffer,
-                    // leaving the original for GC
-                    responseBuffer = tmpNewBuffer;
+                // And now the new chunk
+                chunk.copy(tmpNewBuffer, responseBuffer.length, 0, chunk.length);
 
-                } else {
-                    // Oh dear oh dear! The response is not only more data
-                    // than we were initially told, but it also exceeds the
-                    // maximum amount of data we're prepared to download per
-                    // resource.
-                    //
-                    // Throw error event and ignore.
-                    //
-                    // We'll then deal with the data that we have.
+                // And now make the response buffer our new buffer,
+                // leaving the original for GC
+                responseBuffer = tmpNewBuffer;
 
-                    crawler.emit("fetchdataerror", queueItem, response);
-                }
             } else {
-                // Copy the chunk data into our main buffer
-                chunk.copy(responseBuffer, responseLengthReceived, 0, chunk.length);
+                // Oh dear oh dear! The response is not only more data
+                // than we were initially told, but it also exceeds the
+                // maximum amount of data we're prepared to download per
+                // resource.
+                //
+                // Throw error event and ignore.
+                //
+                // We'll then deal with the data that we have.
+
+                crawler.emit("fetchdataerror", queueItem, response);
             }
-
-            // Increment our data received counter
-            responseLengthReceived += chunk.length;
+        } else {
+            // Copy the chunk data into our main buffer
+            chunk.copy(responseBuffer, responseLengthReceived, 0, chunk.length);
         }
 
-        if ((responseLengthReceived >= responseLength || response.complete) &&
-            !dataReceived) {
-
-            // Slice the buffer to chop off any unused space
-            responseBuffer = responseBuffer.slice(0, responseLengthReceived);
-
-            dataReceived = true;
-            processReceivedData();
-        }
+        // Increment our data received counter
+        responseLengthReceived += chunk.length;
     }
 
     // If we should just go ahead and get the data
@@ -1158,7 +1153,7 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
             crawler.mimeTypeSupported(contentType)) {
 
             response.on("data", receiveData);
-            response.on("end", receiveData);
+            response.on("end", processReceivedData);
         } else {
             queueItem.fetched = true;
             crawler._openRequests--;

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -1103,39 +1103,23 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
 
             if (responseLengthReceived + chunk.length <= crawler.maxResourceSize) {
 
-                // Start by creating a new buffer, which will be our main
-                // buffer from now on...
-
+                // Create a temporary buffer with the new response length, copy
+                // the old data into it and replace the old buffer with it
                 var tmpNewBuffer = new Buffer(responseLengthReceived + chunk.length);
-
-                // Copy all our old data into it...
                 responseBuffer.copy(tmpNewBuffer, 0, 0, responseBuffer.length);
-
-                // And now the new chunk
                 chunk.copy(tmpNewBuffer, responseBuffer.length, 0, chunk.length);
-
-                // And now make the response buffer our new buffer,
-                // leaving the original for GC
                 responseBuffer = tmpNewBuffer;
-
             } else {
-                // Oh dear oh dear! The response is not only more data
-                // than we were initially told, but it also exceeds the
-                // maximum amount of data we're prepared to download per
-                // resource.
-                //
-                // Throw error event and ignore.
-                //
-                // We'll then deal with the data that we have.
 
+                // The response size exceeds maxResourceSize. Throw event and
+                // ignore. We'll then deal with the data that we have.
+                response.socket.destroy();
                 crawler.emit("fetchdataerror", queueItem, response);
             }
         } else {
-            // Copy the chunk data into our main buffer
             chunk.copy(responseBuffer, responseLengthReceived, 0, chunk.length);
         }
 
-        // Increment our data received counter
         responseLengthReceived += chunk.length;
     }
 


### PR DESCRIPTION
This is an attempt at addressing #192. I've also experienced the problem where certain requests are just "left hanging", they're never closed and cause the process to keep running indefinitely unless timed out.

My solution here was to always close HTTP responses on their "end" event.

I don't see any obvious holes in the old logic, my best guess is that the `complete` property for some reason isn't always set on the response when it is in fact complete. I don't see why that would be, but on the other hand I couldn't find any documentation for that property, so there might be some unpredictable behavior there.

The diff is noisier than my actual changes because of an indentation change, but the basic changes are:
1. call `processReceivedData` directly on the request's "end" event
2. always assume that the `chunk` argument to `receiveData` is defined
3. remove the logic in `receiveData` that calls `processReceivedData`