### PR TITLE
Catch errors from adding cookies and emit event

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ you can modify the crawler request options (including headers and request method
 * `fetchheaders` (queueItem, responseObject)
 Fired when the headers for a resource are received from the server. The node http
 response object is returned for your perusal.
+* `cookieerror` (queueItem, error, setCookieHeader)
+Fired when an error was caught trying to add a cookie to the cookie jar.
 * `fetchcomplete` (queueItem, responseBody, responseObject)
 Fired when the resource is completely downloaded. The response body is provided as
 a Buffer per default, unless `decodeResponses` is truthy, in which case it's a

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -1036,7 +1036,11 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
 
     // Do we need to save cookies? Were we sent any?
     if (crawler.acceptCookies && response.headers.hasOwnProperty("set-cookie")) {
-        crawler.cookies.addFromHeaders(response.headers["set-cookie"]);
+        try {
+            crawler.cookies.addFromHeaders(response.headers["set-cookie"]);
+        } catch (error) {
+            crawler.emit("cookieerror", queueItem, error, response.headers["set-cookie"]);
+        }
     }
 
     // Emit header receive event

--- a/test/lib/routes.js
+++ b/test/lib/routes.js
@@ -13,7 +13,10 @@ module.exports = {
     },
 
     "/stage2": function(write) {
-        write(200, "Stage2. http://127.0.0.1:3000/stage/3");
+        write(200, "Stage2. http://127.0.0.1:3000/stage/3", {
+            // Faulty cookie! Should generate a cookieerror event
+            "Set-Cookie": "=test; path=/stage2; domain=test.com"
+        });
     },
 
     "/stage/3": function(write) {
@@ -66,35 +69,35 @@ module.exports = {
     },
 
     "/css": function(write) {
-        write(200, "/* CSS 1 */ @import url('/css/2'); @font-face { url(/font/1) format('woff'); }", "text/css");
+        write(200, "/* CSS 1 */ @import url('/css/2'); @font-face { url(/font/1) format('woff'); }", { "Content-Type": "text/css" });
     },
 
     "/css/2": function(write) {
-        write(200, "/* CSS 2 */ @import url('/css/3'); .img1 { background-image:url('/img/1'); }", "text/css");
+        write(200, "/* CSS 2 */ @import url('/css/3'); .img1 { background-image:url('/img/1'); }", { "Content-Type": "text/css" });
     },
 
     "/css/3": function(write) {
-        write(200, "/* CSS 3 */", "text/css");
+        write(200, "/* CSS 3 */", { "Content-Type": "text/css" });
     },
 
     "/css/4": function(write) {
-        write(200, "/* CSS 4 */ .img1 { background-image:url('/img/2'); } @font-face { url(/font/2) format('woff'); }", "text/css");
+        write(200, "/* CSS 4 */ .img1 { background-image:url('/img/2'); } @font-face { url(/font/2) format('woff'); }", { "Content-Type": "text/css" });
     },
 
     "/img/1": function(write) {
-        write(200, "", "image/png");
+        write(200, "", { "Content-Type": "image/png" });
     },
 
     "/img/2": function(write) {
-        write(200, "", "image/png");
+        write(200, "", { "Content-Type": "image/png" });
     },
 
     "/font/1": function(write) {
-        write(200, "", "font/woff");
+        write(200, "", { "Content-Type": "font/woff" });
     },
 
     "/font/2": function(write) {
-        write(200, "", "application/font-woff");
+        write(200, "", { "Content-Type": "application/font-woff" });
     },
 
     "/410": function(write) {
@@ -106,7 +109,7 @@ module.exports = {
     },
 
     "/encoded/header": function(write) {
-        write(200, getFixtureFile("encoded.html"), "text/html; charset=ISO-8859-1");
+        write(200, getFixtureFile("encoded.html"), { "Content-Type": "text/html; charset=ISO-8859-1" });
     },
 
     "/encoded/inline": function(write) {

--- a/test/lib/testserver.js
+++ b/test/lib/testserver.js
@@ -12,14 +12,21 @@ var testRoutes = require("./routes");
 // Listen to events
 httpServer.on("request", function(req, res) {
 
-    function write(status, data, contentType) {
-        res.writeHead(
-            status,
-            http.STATUS_CODES[status], {
-                "Content-Type": contentType || "text/html",
-                "Content-Length": data instanceof Buffer ? data.length : Buffer.byteLength(data)
-            });
+    function write(status, data, customHeaders) {
+        var headers = {
+            "Content-Type": "text/html",
+            "Content-Length": data instanceof Buffer ? data.length : Buffer.byteLength(data)
+        };
 
+        if (typeof customHeaders === "object") {
+            for (var header in customHeaders) {
+                if (customHeaders.hasOwnProperty(header)) {
+                    headers[header] = customHeaders[header];
+                }
+            }
+        }
+
+        res.writeHead(status, http.STATUS_CODES[status], headers);
         res.write(data);
         res.end();
     }

--- a/test/testcrawl.js
+++ b/test/testcrawl.js
@@ -34,6 +34,14 @@ describe("Test Crawl", function() {
         localCrawler.running.should.equal(true);
     });
 
+    it("should emit an error when it gets a faulty cookie", function(done) {
+
+        localCrawler.on("cookieerror", function(queueItem) {
+            queueItem.url.should.equal("http://127.0.0.1:3000/stage2");
+            done();
+        });
+    });
+
     it("should have a queue with at least the initial crawl path", function() {
 
         localCrawler.queue.length.should.be.greaterThan(0);


### PR DESCRIPTION
In rare cases, web servers will send out malformed Set-Cookie
headers that could cause simplecrawler's cookie mechanism to throw
an error. Previously, such an error would kill the entire crawler,
but with this change, the crawler simply emits a "cookieerror"
event and continues. Fixes #184.