### PR TITLE
Find resources in <meta> redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,8 @@ Here's a complete list of what you can stuff with at this stage:
     ```
 
 *   `crawler.discoverRegex` -
-    Array of regex objects that simplecrawler uses to discover resources.
+    Array of regular expressions and functions that simplecrawler uses to
+    discover resources. Functions in this array are expected to return an array.
 *   `crawler.cache` -
     Specify a cache architecture to use when crawling. Must implement
     `SimpleCache` interface. You can save the site to disk using the built in file

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -169,7 +169,20 @@ var Crawler = function(host, initialPath, initialPort, interval) {
         // strings out of javacript: URLs. They're often popup-image
         // or preview windows, which would otherwise be unavailable to us.
         // Worst case scenario is we make some junky requests.
-        /^javascript\:[a-z0-9\$\_\.]+\(['"][^'"\s]+/ig
+        /^javascript\:[a-z0-9\$\_\.]+\(['"][^'"\s]+/ig,
+
+        // Find resources in <meta> redirects. We need to wrap these RegExp's in
+        // functions because we only want to return the first capture group, not
+        // the entire match. And we need two RegExp's because the necessary
+        // attributes on the <meta> tag can appear in any order
+        function(string) {
+            var match = string.match(/<\s*meta[^>]*http-equiv=["']{0,1}refresh["']{0,1}[^>]*content=["']{0,1}[^"'>]*url=([^"'>]*)["']{0,1}[^>]*>/i);
+            return Array.isArray(match) ? [match[1]] : undefined;
+        },
+        function(string) {
+            var match = string.match(/<\s*meta[^>]*content=["']{0,1}[^"'>]*url=([^"'>]*)["']{0,1}[^>]*http-equiv=["']{0,1}refresh["']{0,1}[^>]*>/i);
+            return Array.isArray(match) ? [match[1]] : undefined;
+        }
     ];
 
     // Whether to parse inside HTML comments
@@ -559,9 +572,12 @@ Crawler.prototype.discoverResources = function(resourceData, queueItem) {
     // Rough scan for URLs
     return crawler.discoverRegex
         .reduce(function(list, regex) {
+            var resources = typeof regex === "function" ?
+                regex(resourceText) :
+                resourceText.match(regex);
+
             return list.concat(
-                crawler.cleanExpandResources(
-                    resourceText.match(regex), queueItem));
+                crawler.cleanExpandResources(resources, queueItem));
         }, [])
         .reduce(function(list, check) {
             if (list.indexOf(check) < 0) {

--- a/test/discovery.js
+++ b/test/discovery.js
@@ -81,6 +81,18 @@ describe("Crawler link discovery", function() {
         links[1].should.equal("http://example.com/resource");
     });
 
+    it("should find and follow meta redirects", function() {
+
+        var links =
+            discover("<meta http-equiv='refresh' content='0; url=/my/other/page.html'>", {
+                url: "http://example.com/"
+            });
+
+        links.should.be.an("array");
+        links.length.should.equal(1);
+        links[0].should.equal("http://example.com/my/other/page.html");
+    });
+
     it("should ignore HTML comments with parseHTMLComments = false", function() {
 
         crawler.parseHTMLComments = false;


### PR DESCRIPTION
We only discover those resources, we don't treat them as an actual
redirect (eg. emit a "fetchredirect" event). Fixes #190