### PR TITLE
Patch fetchDenied logic.

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -768,9 +768,12 @@ Crawler.prototype.queueURL = function(url, queueItem) {
 
     // Pass this URL past fetch conditions to ensure the user thinks it's valid
     var fetchDenied = false;
-    fetchDenied = crawler._fetchConditions.reduce(function(prev, callback) {
-        return prev || !callback(parsedURL, queueItem);
-    }, false);
+    for (var i = 0; i < crawler._fetchConditions.length; i++) {
+        fetchDenied = crawler._fetchConditions[i](parsedURL, queueItem);
+        if (fetchDenied === false) {
+            break;
+        }
+    }
 
     if (fetchDenied) {
         // Fetch Conditions conspired to block URL

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -770,14 +770,10 @@ Crawler.prototype.queueURL = function(url, queueItem) {
     var fetchDenied = false;
     for (var i = 0; i < crawler._fetchConditions.length; i++) {
         fetchDenied = crawler._fetchConditions[i](parsedURL, queueItem);
-        if (fetchDenied === false) {
-            break;
-        }
-    }
-
-    if (fetchDenied) {
         // Fetch Conditions conspired to block URL
-        return false;
+        if (fetchDenied === false) {
+            return false;
+        }
     }
 
     // Check the domain is valid before adding it to the queue


### PR DESCRIPTION
So that a fetch condition that returns false prevents any further fetch
conditions from being called.

Note that this code can be simplified further by just calling `return` rather than `break`, I'll update this PR if you think this logic is correct and want to merge.