### PR TITLE
Add config option to follow initial redirects to a different domain.

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,10 @@ Here's a complete list of what you can stuff with at this stage:
     &lt;meta charset="xxx" /&gt; tags.
 *    `crawler.queue` -
     The queue in use by the crawler (Must implement the `FetchQueue` interface)
+*   `crawler.allowInitialDomainChange` -
+    If the response for the initial url is a redirect to another domain 
+    (e.g. from github.net to github.com), update `crawler.host` to
+    continue the crawling on that domain. Defaults to false.
 *    `crawler.filterByDomain` -
     Specifies whether the crawler will restrict queued requests to a given
     domain/domains.

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -82,6 +82,9 @@ var Crawler = function(host, initialPath, initialPort, interval) {
     // (but it's basically just an array)
     crawler.queue           = new FetchQueue();
 
+    // Should we update crawler.host if the first response is a redirect to another domain.
+    crawler.allowInitialDomainChange = false;
+
     // Decode HTTP responses based on their Content-Type header or any
     // inline charset definition
     crawler.decodeResponses = false;
@@ -206,6 +209,7 @@ var Crawler = function(host, initialPath, initialPort, interval) {
 
     // STATE (AND OTHER) VARIABLES NOT TO STUFF WITH
     var hiddenProps = {
+        _isFirstRequest:	true,
         _openRequests: 0,
         _fetchConditions: [],
         _openListeners: 0
@@ -1182,7 +1186,9 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
             crawler.emit("notmodified", queueItem, response);
         }
 
-    // If we should queue a redirect
+        crawler._isFirstRequest = false;
+
+        // If we should queue a redirect
     } else if (response.statusCode >= 300 && response.statusCode < 400 &&
                     response.headers.location) {
 
@@ -1194,6 +1200,10 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
 
         // Emit redirect event
         crawler.emit("fetchredirect", queueItem, parsedURL, response);
+
+        if (crawler.allowInitialDomainChange && crawler._isFirstRequest) {
+            crawler.host = parsedURL.host;
+        }
 
         // Clean URL, add to queue...
         crawler.queueURL(parsedURL, queueItem);
@@ -1212,7 +1222,9 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
 
         crawler._openRequests--;
 
-    // And oh dear. Handle this one as well. (other 400s, 500s, etc)
+        crawler._isFirstRequest = false;
+
+        // And oh dear. Handle this one as well. (other 400s, 500s, etc)
     } else {
         queueItem.fetched = true;
         queueItem.status = "failed";
@@ -1222,6 +1234,8 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
         response.socket.destroy();
 
         crawler._openRequests--;
+
+        crawler._isFirstRequest = false;
     }
 
     return crawler;

--- a/test/lib/routes.js
+++ b/test/lib/routes.js
@@ -55,6 +55,14 @@ module.exports = {
         // We want to trigger a timeout. Never respond.
     },
 
+    "/domain-redirect": function(write, redir) {
+        redir("http://127.0.0.1:3000/");
+    },
+
+    "/to-domain-redirect": function(write) {
+        write(200, "<a href='/domain-redirect'>redirect</a>");
+    },
+
     // Routes for depth tests
     "/depth/1": function(write) {
         write(200, "<link rel='stylesheet' href='/css'> Home. <a href='/depth/2'>depth2</a>");

--- a/test/testcrawl.js
+++ b/test/testcrawl.js
@@ -129,6 +129,52 @@ describe("Test Crawl", function() {
         });
     });
 
+    it("should allow initial redirect to different domain if configured", function(done) {
+        var crawler = makeCrawler("0.0.0.0", "/domain-redirect", 3000);
+
+        crawler.allowInitialDomainChange = true;
+
+        crawler.on("queueadd", function(queueItem) {
+            queueItem.host.should.equal("127.0.0.1");
+            crawler.stop();
+            done();
+        });
+
+        crawler.start();
+    });
+
+    it("should only allow redirect to different domain for initial request", function(done) {
+        var crawler = makeCrawler("0.0.0.0", "/to-domain-redirect", 3000),
+            linksDiscovered = 0;
+
+        crawler.on("discoverycomplete", function() {
+            linksDiscovered++;
+        });
+
+        crawler.on("complete", function() {
+            linksDiscovered.should.equal(1);
+            done();
+        });
+
+        crawler.start();
+    });
+
+    it("should disallow initial redirect to different domain by default", function(done) {
+        var crawler = makeCrawler("0.0.0.0", "/domain-redirect", 3000),
+            linksDiscovered = 0;
+
+        crawler.on("discoverycomplete", function() {
+            linksDiscovered++;
+        });
+
+        crawler.on("complete", function() {
+            linksDiscovered.should.equal(0);
+            done();
+        });
+
+        crawler.start();
+    });
+
     // TODO
 
     // Test how simple error conditions are handled


### PR DESCRIPTION
If crawler.allowInitialDomainChange is set to true, and the initial url redirects to a different domain (e.g. a .com redirects to a canonical .net domain), crawler.host is updated to the new domain, to allow crawling to continue on that domain.

The is a re-post of #74.