### PR TITLE
Redirects should not change the depth on the initial request

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -1380,6 +1380,7 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
         crawler.emit("fetchredirect", queueItem, parsedURL, response);
 
         if (crawler.allowInitialDomainChange && crawler._isFirstRequest) {
+            parsedURL.depth = 1;
             crawler.host = parsedURL.host;
         }
 

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -1350,6 +1350,8 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
             response.socket.destroy();
         }
 
+        crawler._isFirstRequest = false;
+
     // We've got a not-modified response back
     } else if (response.statusCode === 304) {
 
@@ -1379,8 +1381,11 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
         // Emit redirect event
         crawler.emit("fetchredirect", queueItem, parsedURL, response);
 
-        if (crawler.allowInitialDomainChange && crawler._isFirstRequest) {
+        if (crawler._isFirstRequest) {
             parsedURL.depth = 1;
+        }
+
+        if (crawler.allowInitialDomainChange && crawler._isFirstRequest) {
             crawler.host = parsedURL.host;
         }
 

--- a/test/lib/routes.js
+++ b/test/lib/routes.js
@@ -68,6 +68,10 @@ module.exports = {
         redir("http://localhost:3000/");
     },
 
+    "/domain-redirect2": function(write, redir) {
+        redir("http://localhost:3000/domain-redirect");
+    },
+
     "/to-domain-redirect": function(write) {
         write(200, "<a href='/domain-redirect'>redirect</a>");
     },

--- a/test/testcrawl.js
+++ b/test/testcrawl.js
@@ -254,6 +254,42 @@ describe("Test Crawl", function() {
         crawler.start();
     });
 
+    it("should not increase depth on multiple redirects on the initial request", function(done) {
+        var crawler = makeCrawler("localhost", "/domain-redirect2", 3000),
+            depth = 1;
+
+        crawler.on("fetchredirect", function(queueItem) {
+            if (queueItem.depth > 1) {
+                depth = queueItem.depth;
+            }
+        });
+
+        crawler.on("complete", function() {
+            depth.should.equal(1);
+            done();
+        });
+
+        crawler.start();
+    });
+
+    it("should disallow initial redirect to different domain after a 2xx", function(done) {
+        var crawler = makeCrawler("127.0.0.1", "/to-domain-redirect", 3000),
+            discoComplete = 0;
+
+        crawler.allowInitialDomainChange = true;
+
+        crawler.on("discoverycomplete", function() {
+            discoComplete++;
+        });
+
+        crawler.on("complete", function() {
+            discoComplete.should.equal(1);
+            done();
+        });
+
+        crawler.start();
+    });
+
     // TODO
 
     // Test how simple error conditions are handled


### PR DESCRIPTION
If allowInitialDomainChange is true crawls with maxDepth=1 will fail if depth is not reset.