### PR TITLE
Decompress compressed responses before emitting fetchcomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,8 +279,13 @@ change to adapt it to your specific needs.
     The maximum time in milliseconds the crawler will wait for async listeners.
 * `crawler.userAgent="Node/simplecrawler <version> (https://github.com/cgiffard/node-simplecrawler)"` -
     The user agent the crawler will report.
+* `crawler.decompressResponses=true` -
+    Response bodies that are compressed will be automatically decompressed
+    before they're emitted in the `fetchcomplete` event. Even if this is falsy,
+    compressed responses will be decompressed before they're passed to the
+    `discoverResources` method.
 * `crawler.decodeResponses=false` -
-    The response bodies will be intelligently character converted to standard
+    Response bodies will be intelligently character converted to standard
     JavaScript strings using the
     [iconv-lite](https://www.npmjs.com/package/iconv-lite) module. The character
     encoding is interpreted from the Content-Type header firstly, and secondly

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -89,6 +89,10 @@ var Crawler = function(host, initialPath, initialPort, interval) {
     // Should we update crawler.host if the first response is a redirect to another domain.
     crawler.allowInitialDomainChange = false;
 
+    // Set Accept-Encoding header and automatically decompress HTTP responses
+    // based on Content-Encoding header
+    crawler.decompressResponses = true;
+
     // Decode HTTP responses based on their Content-Type header or any
     // inline charset definition
     crawler.decodeResponses = false;
@@ -381,11 +385,14 @@ Crawler.prototype.getRequestOptions = function (queueItem) {
         agent: agent,
         headers: {
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-            "Accept-Encoding": "gzip, deflate",
             "User-Agent": crawler.userAgent,
             "Host": queueItem.host + (isStandardHTTPPort || isStandardHTTPSPort ? ":" + queueItem.port : "")
         }
     };
+
+    if (crawler.decompressResponses) {
+        requestOptions.headers["Accept-Encoding"] = "gzip, deflate";
+    }
 
     if (queueItem.referrer) {
         requestOptions.headers.Referer = queueItem.referrer;
@@ -937,13 +944,11 @@ Crawler.prototype.domainValid = function(host) {
     one, since this function queues the resources in addition to
     discovering them.
 
-    resourceData    - Text document containing linked resource URLs.
-    queueItem       - Queue item from which the resource document was derived.
-    decompressed    - Content is already decompressed (default: false)
+    resourceData - Text document containing linked resource URLs.
+    queueItem    - Queue item from which the resource document was derived.
 
     Emits
 
-        gziperr
         discoverycomplete
 
     Examples
@@ -953,22 +958,10 @@ Crawler.prototype.domainValid = function(host) {
     Returns the crawler object for chaining.
 
 */
-Crawler.prototype.queueLinkedItems = function(resourceData, queueItem, decompressed) {
-    var crawler = this,
-        resources = [],
-        contentEncoding = queueItem.stateData.headers["content-encoding"];
+Crawler.prototype.queueLinkedItems = function(resourceData, queueItem) {
+    var crawler = this;
 
-    if (!decompressed && contentEncoding && /(gzip|deflate)/.test(contentEncoding)) {
-        return zlib.unzip(resourceData, function(err, newData) {
-            if (err) {
-                return crawler.emit("gziperror", queueItem, err, resourceData);
-            }
-
-            crawler.queueLinkedItems(newData, queueItem, true);
-        });
-    }
-
-    resources = crawler.discoverResources(resourceData, queueItem);
+    var resources = crawler.discoverResources(resourceData, queueItem);
 
     // Emit discovered resources. ie: might be useful in building a graph of
     // page relationships.
@@ -1221,12 +1214,12 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
     responseLength = !isNaN(responseLength) ? responseLength : 0;
 
     // Save timing and content some header information into queue
-    stateData.requestLatency    = timeHeadersReceived - timeCommenced;
-    stateData.requestTime       = timeHeadersReceived - timeCommenced;
-    stateData.contentLength     = responseLength;
-    stateData.contentType       = contentType = response.headers["content-type"];
-    stateData.code              = response.statusCode;
-    stateData.headers           = response.headers;
+    stateData.requestLatency = timeHeadersReceived - timeCommenced;
+    stateData.requestTime    = timeHeadersReceived - timeCommenced;
+    stateData.contentLength  = responseLength;
+    stateData.contentType    = contentType = response.headers["content-type"];
+    stateData.code           = response.statusCode;
+    stateData.headers        = response.headers;
 
     // Do we need to save cookies? Were we sent any?
     if (crawler.acceptCookies && response.headers.hasOwnProperty("set-cookie")) {
@@ -1241,10 +1234,19 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
     crawler.emit("fetchheaders", queueItem, response);
 
     // Ensure response length is reasonable...
-    responseLength =
-        responseLength > 0 ? responseLength : crawler.maxResourceSize;
-
+    responseLength = responseLength > 0 ? responseLength : crawler.maxResourceSize;
     queueItem.stateData.contentLength = responseLength;
+
+    function emitFetchComplete(responseBody, decompressedBuffer) {
+        responseBody = crawler.decodeResponses ? crawler.decodeBuffer(responseBody, stateData.contentType) : responseBody;
+        crawler.emit("fetchcomplete", queueItem, responseBody, response);
+
+        // We only process the item if it's of a valid mimetype
+        // and only if the crawler is set to discover its own resources
+        if (crawler.mimeTypeSupported(contentType) && crawler.discoverResources) {
+            crawler.queueLinkedItems(decompressedBuffer || responseBody, queueItem);
+        }
+    }
 
     // Function for dealing with 200 responses
     function processReceivedData() {
@@ -1271,17 +1273,23 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
             crawler.cache.setCacheData(queueItem, responseBuffer);
         }
 
-        // Is the item allowed by depth conditions ?
         if (crawler.depthAllowed(queueItem)) {
-            var responseBody =
-                crawler.decodeResponses ? crawler.decodeBuffer(responseBuffer, stateData.contentType) : responseBuffer;
-
-            crawler.emit("fetchcomplete", queueItem, responseBody, response);
-
-            // We only process the item if it's of a valid mimetype
-            // and only if the crawler is set to discover its own resources
-            if (crawler.mimeTypeSupported(contentType) && crawler.discoverResources) {
-                crawler.queueLinkedItems(responseBuffer, queueItem);
+            // No matter the value of `crawler.decompressResponses`, we still
+            // decompress the response if it's gzipped or deflated. This is
+            // because we always provide the discoverResources method with a
+            // decompressed buffer
+            if (/(gzip|deflate)/.test(stateData.headers["content-encoding"])) {
+                zlib.unzip(responseBuffer, function(error, decompressedBuffer) {
+                    if (error) {
+                        crawler.emit("gziperror", queueItem, error, responseBuffer);
+                        emitFetchComplete(responseBuffer);
+                    } else {
+                        var responseBody = crawler.decompressResponses ? decompressedBuffer : responseBuffer;
+                        emitFetchComplete(responseBody, decompressedBuffer);
+                    }
+                });
+            } else {
+                emitFetchComplete(responseBuffer);
             }
         }
 

--- a/test/lib/routes.js
+++ b/test/lib/routes.js
@@ -1,7 +1,8 @@
 // Routes for testing server
 
 var fs = require("fs"),
-    path = require("path");
+    path = require("path"),
+    zlib = require("zlib");
 
 var getFixtureFile = function (filename) {
     return fs.readFileSync(path.join(__dirname, "..", "fixtures", filename));
@@ -155,6 +156,24 @@ module.exports = {
 
     "/encoded/empty": function(write) {
         write(200, "");
+    },
+
+    "/compressed/link": function(write) {
+        zlib.gzip("<a href='/compressed/gzip'>Go to gzip</a>", function(error, result) {
+            write(200, result, { "Content-Encoding": "gzip" });
+        });
+    },
+
+    "/compressed/gzip": function(write) {
+        zlib.gzip("Yay, you know how to deal with gzip compression!", function(error, result) {
+            write(200, result, { "Content-Encoding": "gzip" });
+        });
+    },
+
+    "/compressed/deflate": function(write) {
+        zlib.deflate("Yay, you know how to deal with deflate compression!", function(error, result) {
+            write(200, result, { "Content-Encoding": "deflate" });
+        });
     },
 
     "/big": function(write) {


### PR DESCRIPTION
By default, responses that are gzipped or deflated are now
decompressed before they're emitted in the fetchcomplete event.
Previously they have only been decompressed before resource
discovery (and they are still always), but now the
`crawler.decompressResponses` setting (true by default) determines
whether the fetchcomplete response should be decompressed as well.

In theory this could boost performance, since we're doing the same
amount of computation as previously, but with less network
traffic.

Fixes #260