### PR TITLE
Add configuration option for 'whitelistedMimeTypes'

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,9 +381,15 @@ change to adapt it to your specific needs.
     be downloaded. Asset files are excluded from this distance condition if
     `crawler.fetchWhitelistedMimeTypesBelowMaxDepth` is `true`. Defaults to `0` —
     no max depth.
+* `crawler.whitelistedMimeTypes` -
+    An array of RegEx objects used to determine whitelisted MIME types (types of
+    data simplecrawler will fetch on disregardig the `maxDepth` checks).
+    Defaults to common resource types like styles, fonts, scripts and images.
 * `crawler.fetchWhitelistedMimeTypesBelowMaxDepth=false` -
-    If `true`, then resources (fonts, images, CSS) will be excluded from
-    `maxDepth` checks. (And therefore downloaded regardless of their depth.)
+    Defines the depth for fetching resources in addition to maxDepth. If `true`,
+    then resources (see `whitelistedMimeTypes`) will always be loaded, while
+    `false` limits them to the same level. Furthermore a numeric value can be
+    specified for a concrete offset (e.g. 1 for the next depth layer).
 * `crawler.ignoreInvalidSSL=false` -
     Treat self-signed SSL certificates as valid. SSL certificates will not be
     validated against known CAs. Only applies to https requests. You may also
@@ -709,7 +715,7 @@ list below before submitting an issue.
     need to react more than once to what happens in simplecrawler.
 
 - **Q: Something's happening and I don't see the output I'm expecting!**
-    
+
     Before filing an issue, check to see that you're not just missing something by
     logging *all* crawler events with the code below:
 
@@ -738,7 +744,7 @@ list below before submitting an issue.
         originalEmit.apply(crawler, arguments);
     };
     ```
-    
+
     If you don't see what you need after inserting that code block, and you still need help,
     please attach the output of all the events fired with your email/issue.
 

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -213,6 +213,16 @@ var Crawler = function(host, initialPath, initialPort, interval) {
     // Max depth parameter
     crawler.maxDepth = 0;
 
+    // Matching MIME-types will be allowed to fetch further than max depth
+    crawler.whitelistedMimeTypes = [
+        /^text\/(css|javascript|ecmascript)/i,
+        /^application\/javascript/i,
+        /^application\/x-font/i,
+        /^application\/font/i,
+        /^image\//i,
+        /^font\//i
+    ];
+
     // Whether to allow 'resources' greater than the max depth to be downloaded
     crawler.fetchWhitelistedMimeTypesBelowMaxDepth = false;
 
@@ -609,23 +619,20 @@ Crawler.prototype.mimeTypeSupported = function(MIMEType) {
 Crawler.prototype.depthAllowed = function(queueItem) {
     var crawler = this;
 
-    // Items matching this pattern will always be fetched, even if max depth
-    // is reached
-    var mimeTypesWhitelist = [
-        /^text\/(css|javascript|ecmascript)/i,
-        /^application\/javascript/i,
-        /^application\/x-font/i,
-        /^application\/font/i,
-        /^image\//i,
-        /^font\//i
-    ];
+    var belowMaxDepth = crawler.fetchWhitelistedMimeTypesBelowMaxDepth;
+
+    if (typeof belowMaxDepth === "boolean") {
+        belowMaxDepth = belowMaxDepth === false ? 0 : Infinity;
+    }
+
+    var whitelistedDepth = queueItem.depth - belowMaxDepth;
 
     return crawler.maxDepth === 0 ||
            queueItem.depth <= crawler.maxDepth ||
-               crawler.fetchWhitelistedMimeTypesBelowMaxDepth &&
-               mimeTypesWhitelist.reduce(function(prev, mimeCheck) {
-                   return prev || !!mimeCheck.exec(queueItem.stateData.contentType);
-               }, false);
+                whitelistedDepth <= crawler.maxDepth &&
+                crawler.whitelistedMimeTypes.some(function(mimeCheck) {
+                    return mimeCheck.test(queueItem.stateData.contentType);
+                });
 };
 
 /*

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -607,10 +607,6 @@ Crawler.prototype.mimeTypeSupported = function(MIMEType) {
     need its MIME type). This will just determine if we need to send an event
     for this item & if we need to fetch linked resources.
 
-    If the queue item is a CSS or JS file, it will always be fetched (we need
-    all images in CSS files, even if max depth is already reached). If it's an
-    HTML page, we will check if max depth is reached or not.
-
         queueItem   - Queue item object to check
 
     Returns a boolean, true if the queue item can be fetched - false if not.


### PR DESCRIPTION
In addition to #272 (which was btw. just meant to assist developers to debug the current system) I think its useful to provide an option to configure the `whitelistedMimeTypes` for checking which data should be kept after fetching them. Currently these are [hardcoded in the library](https://github.com/cgiffard/node-simplecrawler/blob/master/lib/crawler.js#L614) and can't be modified (e.g. for checking the `text/html` content-type). The modification is focusing on backwards compatibility to existing code and therefore completely optional for cases its needed.

The issue #249 @fredrikekelund mentioned last time will probably cover similar scenarios but won't allow a seamless integration without changing parts of the internals.