### PR TITLE
Use 'Array.protoype.some' instead of 'Array.prototype.reduce' for contains

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -564,9 +564,9 @@ Crawler.prototype.protocolSupported = function(URL) {
         return false;
     }
 
-    return crawler.allowedProtocols.reduce(function(prev, protocolCheck) {
-        return prev || !!protocolCheck.exec(protocol);
-    }, false);
+    return crawler.allowedProtocols.some(function(protocolCheck) {
+        return protocolCheck.test(protocol);
+    });
 };
 
 /*
@@ -585,9 +585,9 @@ Crawler.prototype.protocolSupported = function(URL) {
 Crawler.prototype.mimeTypeSupported = function(MIMEType) {
     var crawler = this;
 
-    return crawler.supportedMimeTypes.reduce(function(prev, mimeCheck) {
-        return prev || !!mimeCheck.exec(MIMEType);
-    }, false);
+    return crawler.supportedMimeTypes.some(function(mimeCheck) {
+        return mimeCheck.test(MIMEType);
+    });
 };
 
 /*
@@ -772,9 +772,9 @@ Crawler.prototype.cleanExpandResources = function (urlMatch, queueItem) {
             }
 
             // Does the item already exist in the list?
-            if (list.reduce(function(prev, current) {
-                return prev || current === URL;
-            }, false)) {
+            if (list.some(function(entry) {
+                return entry === URL;
+            })) {
                 return list;
             }
 
@@ -870,27 +870,18 @@ Crawler.prototype.domainValid = function(host) {
         }
 
         // Otherwise, scan through it.
-        return !!crawler.domainWhitelist.reduce(function(prev, cur) {
-
-            // If we already located the relevant domain in the whitelist...
-            if (prev) {
-                return prev;
-            }
-
+        return !!crawler.domainWhitelist.some(function(entry) {
             // If the domain is just equal, return true.
-            if (host === cur) {
+            if (host === entry) {
                 return true;
             }
-
             // If we're ignoring WWW subdomains, and both domains,
             // less www. are the same, return true.
-            if (crawler.ignoreWWWDomain && host === cur.replace(/^www\./i, "")) {
+            if (crawler.ignoreWWWDomain && host === entry.replace(/^www\./i, "")) {
                 return true;
             }
-
-            // Otherwise, sorry. No dice.
             return false;
-        }, false);
+        });
     }
 
     // Checks if the first domain is a subdomain of the second
@@ -1013,9 +1004,9 @@ Crawler.prototype.queueURL = function(url, queueItem) {
     }
 
     // Pass this URL past fetch conditions to ensure the user thinks it's valid
-    var fetchDenied = crawler._fetchConditions.reduce(function(prev, callback) {
-        return prev || !callback(parsedURL, queueItem);
-    }, false);
+    var fetchDenied = crawler._fetchConditions.some(function(callback) {
+        return !callback(parsedURL, queueItem);
+    });
 
     if (fetchDenied) {
         // Fetch Conditions conspired to block URL


### PR DESCRIPTION
For a better understanding whats happening and an increased performance, [Array.prototype.some](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) is used instead of [Array.prototype.reduce](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce) for lookups.
