### PR TITLE
Fix redirect from HTTP to HTTPS

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -1162,7 +1162,6 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
 
     // We should just go ahead and get the data
     } else if (response.statusCode >= 200 && response.statusCode < 300) {
-
         queueItem.status = "headers";
 
         // Create a buffer with our response length
@@ -1218,6 +1217,11 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
 
         if (crawler.allowInitialDomainChange && crawler._isFirstRequest) {
             crawler.host = parsedURL.host;
+        }
+
+        // switch port on redirect to TLS/SSL
+        if (parsedURL.protocol === "https") {
+            parsedURL.port = 443;
         }
 
         // Clean URL, add to queue...


### PR DESCRIPTION
Fixed bug caused by redirect from HTTP to HTTPS. In this case then protocol is updated, but simplecrawler attempts to crawl via the previous redirected URLs port (previously 80) causing a 404/410 error to be returned by some servers.

This was previously reported as follows:

https://github.com/cgiffard/node-simplecrawler/issues/145
https://github.com/cgiffard/node-simplecrawler/issues/208

Test cases are difficult to compose for this case because it requires a working TLS/SSL server in the test code.