### PR TITLE
https port fix

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -697,7 +697,7 @@ Crawler.prototype.processURL = function(URL, context) {
     return {
         protocol: newURL.protocol() || "http",
         host:     newURL.hostname(),
-        port:     newURL.port() || 80,
+        port:     newURL.port() || (newURL.protocol() === "https" ? 443 : 80),
         path:     newURL.resource(),
         uriPath:  newURL.path(),
         depth:    context.depth + 1

--- a/test/resourcevalidity.js
+++ b/test/resourcevalidity.js
@@ -284,5 +284,16 @@ describe("Resource validity checker", function() {
 
         });
 
+        it("should make sure the port number is not empty", function () {
+
+            var crawler = makeCrawler("example.com", 3000);
+
+            crawler.processURL("http://www.example.com").port.should.equal(80);
+            crawler.processURL("http://www.example.com:80").port.should.equal(80);
+            crawler.processURL("https://www.example.com").port.should.equal(443);
+            crawler.processURL("https://www.example.com:443").port.should.equal(443);
+
+        });
+
     });
 });


### PR DESCRIPTION
I didn't check why, but sometimes URIjs returns `protocol() === https` and empty `port()`, so we need to make sure it is 443 for https:// addresses.