### PR TITLE
Crawler: Enabled stop to forcibly terminate in-flight requests

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -239,8 +239,8 @@ var Crawler = function(initialURL) {
     // STATE (AND OTHER) VARIABLES NOT TO STUFF WITH
     var hiddenProps = {
         _robotsTxts: [],
-        _isFirstRequest:	true,
-        _openRequests: 0,
+        _isFirstRequest: true,
+        _openRequests: [],
         _fetchConditions: [],
         _openListeners: 0
     };
@@ -1063,7 +1063,6 @@ Crawler.prototype.queueURL = function(url, referrer) {
 */
 Crawler.prototype.fetchQueueItem = function(queueItem) {
     var crawler = this;
-    crawler._openRequests++;
 
     // Variable declarations
     var clientRequest,
@@ -1087,10 +1086,6 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
 
     var requestOptions = crawler.getRequestOptions(queueItem);
 
-    // Emit fetchstart event - gives the user time to mangle the request options
-    // if required.
-    crawler.emit("fetchstart", queueItem, requestOptions);
-
     // Record what time we started this request
     timeCommenced = Date.now();
 
@@ -1102,13 +1097,27 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
 
     clientRequest.end();
 
+    // Enable central tracking of this request
+    crawler._openRequests.push(clientRequest);
+
+    // Ensure the request is removed from the tracking array if it is
+    // forcibly aborted
+    clientRequest.on("abort", function() {
+        if (crawler._openRequests.indexOf(clientRequest) > -1) {
+            crawler._openRequests.splice(
+                crawler._openRequests.indexOf(clientRequest), 1);
+        }
+    });
+
     clientRequest.setTimeout(crawler.timeout, function() {
         if (queueItem.fetched) {
             return;
         }
 
         if (crawler.running && !queueItem.fetched) {
-            crawler._openRequests--;
+            // Remove this request from the open request map
+            crawler._openRequests.splice(
+                crawler._openRequests.indexOf(clientRequest), 1);
         }
 
         queueItem.fetched = true;
@@ -1127,7 +1136,9 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
         }
 
         if (crawler.running && !queueItem.fetched) {
-            crawler._openRequests--;
+            // Remove this request from the open request map
+            crawler._openRequests.splice(
+                crawler._openRequests.indexOf(clientRequest), 1);
         }
 
         // Emit 5xx / 4xx event
@@ -1136,6 +1147,13 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
         queueItem.status = "failed";
         crawler.emit("fetchclienterror", queueItem, errorData);
     });
+
+    // Emit fetchstart event once everything about the request has been
+    // established.
+    //
+    // This code previously relied on a side-effect to enable per-request
+    // mangling of the request options, but that was probably not a good idea.
+    crawler.emit("fetchstart", queueItem, requestOptions);
 
     return crawler;
 };
@@ -1281,7 +1299,9 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
             }
         }
 
-        crawler._openRequests--;
+        // Remove this request from the open request map
+        crawler._openRequests.splice(
+            crawler._openRequests.indexOf(response.req), 1);
     }
 
     function receiveData(chunk) {
@@ -1320,7 +1340,10 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
     // We already know that the response will be too big
     if (responseLength > crawler.maxResourceSize) {
         queueItem.fetched = true;
-        crawler._openRequests--;
+
+        // Remove this request from the open request map
+        crawler._openRequests.splice(
+            crawler._openRequests.indexOf(response.req), 1);
 
         response.socket.destroy();
         crawler.emit("fetchdataerror", queueItem, response);
@@ -1341,7 +1364,10 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
             response.on("end", processReceivedData);
         } else {
             queueItem.fetched = true;
-            crawler._openRequests--;
+
+            // Remove this request from the open request map
+            crawler._openRequests.splice(
+                crawler._openRequests.indexOf(response.req), 1);
 
             response.socket.destroy();
         }
@@ -1389,7 +1415,9 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
         crawler.queueURL(referrerQueueItem, queueItem);
         response.socket.destroy();
 
-        crawler._openRequests--;
+        // Remove this request from the open request map
+        crawler._openRequests.splice(
+            crawler._openRequests.indexOf(response.req), 1);
 
     // Ignore this request, but record that we had a 404
     } else if (response.statusCode === 404 || response.statusCode === 410) {
@@ -1400,7 +1428,9 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
         crawler.emit("fetch" + response.statusCode, queueItem, response);
         response.socket.destroy();
 
-        crawler._openRequests--;
+        // Remove this request from the open request map
+        crawler._openRequests.splice(
+            crawler._openRequests.indexOf(response.req), 1);
 
         crawler._isFirstRequest = false;
 
@@ -1413,7 +1443,9 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
         crawler.emit("fetcherror", queueItem, response);
         response.socket.destroy();
 
-        crawler._openRequests--;
+        // Remove this request from the open request map
+        crawler._openRequests.splice(
+            crawler._openRequests.indexOf(response.req), 1);
 
         crawler._isFirstRequest = false;
     }
@@ -1437,7 +1469,7 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
 Crawler.prototype.crawl = function() {
     var crawler = this;
 
-    if (crawler._openRequests > crawler.maxConcurrency ||
+    if (crawler._openRequests.length > crawler.maxConcurrency ||
         crawler.fetchingRobotsTxt) {
         return [];
     }
@@ -1484,7 +1516,7 @@ Crawler.prototype.crawl = function() {
 
                 crawler.fetchQueueItem(queueItem);
             }
-        } else if (!crawler._openRequests && !crawler._openListeners) {
+        } else if (!crawler._openRequests.length && !crawler._openListeners) {
 
             crawler.queue.countItems({ fetched: true }, function (err, completeCount) {
                 if (err) {
@@ -1509,19 +1541,32 @@ Crawler.prototype.crawl = function() {
 };
 
 /*
-    Public: Stops the crawler, terminating the crawl runloop.
+    Public: Stops the crawler, terminating the crawl runloop. Given a boolean
+    argument, this method will forcibly terminate any existing requests
+    in-flight.
 
     Examples
 
         crawler.stop();
 
+        // Force the crawler to abort any requests currently in-flight.
+        crawler.stop(true);
+
     Returns the crawler object for chaining.
 
 */
-Crawler.prototype.stop = function() {
+Crawler.prototype.stop = function(abortRequestsInFlight) {
     var crawler = this;
     clearInterval(crawler.crawlIntervalID);
     crawler.running = false;
+
+    // If we've been asked to terminate the existing requests, do that now.
+    if (abortRequestsInFlight) {
+        crawler._openRequests.forEach(function(request) {
+            request.abort();
+        });
+    }
+
     return crawler;
 };
 

--- a/test/lib/testserver.js
+++ b/test/lib/testserver.js
@@ -59,6 +59,14 @@ var Server = function(routes) {
     });
 
     this.on("error", function (error) {
+        // If we've already started a server, don't worry that we couldn't
+        // start another one.
+        // This will happen, for instance, with mocha-watch.
+
+        if (error.code === "EADDRINUSE") {
+            return;
+        }
+
         console.log(error);
         process.exit(1);
     });

--- a/test/reliability.js
+++ b/test/reliability.js
@@ -41,7 +41,7 @@ describe("Crawler reliability", function() {
 
         localCrawler.on("fetchtimeout", function() {
             timesCalled++;
-            localCrawler._openRequests.should.equal(0);
+            localCrawler._openRequests.should.eql([]);
 
             if (timesCalled === 2) {
                 done();
@@ -59,7 +59,7 @@ describe("Crawler reliability", function() {
         localCrawler.queueURL("http://127.0.0.1:3000/img/2");
 
         localCrawler.on("complete", function() {
-            localCrawler._openRequests.should.equal(0);
+            localCrawler._openRequests.should.eql([]);
             done();
         });
 
@@ -157,5 +157,74 @@ describe("Crawler reliability", function() {
         }, 10);
 
         localCrawler.start();
+    });
+
+    describe("when stopping the crawler", function() {
+
+        it("should not terminate open connections unless asked", function(done) {
+            var localCrawler = Crawler.crawl("http://127.0.0.1:3000/");
+            var fetchStartCallCount = 0;
+
+            // Speed things up
+            localCrawler.interval = 0;
+
+            // Adding routes which will time out, so we don't ever end up
+            // completing the crawl before we can instrument the requests
+            localCrawler.queueURL("/timeout");
+            localCrawler.queueURL("/timeout2");
+
+            localCrawler.on("fetchstart", function() {
+
+                // If we haven't been called previously
+                if (!fetchStartCallCount) {
+                    return fetchStartCallCount++;
+                }
+
+                localCrawler._openRequests.forEach(function(req) {
+                    req.abort = function() {
+                        throw new Error("Should not abort requests!");
+                    };
+                });
+
+                localCrawler.stop();
+                done();
+            });
+        });
+
+        it("should terminate open connections when requested", function(done) {
+            var localCrawler = Crawler.crawl("http://127.0.0.1:3000/");
+            var fetchStartCallCount = 0,
+                abortCallCount = 0;
+
+            // Speed things up
+            localCrawler.interval = 0;
+
+            // Adding routes which will time out, so we don't ever end up
+            // completing the crawl before we can instrument the requests
+            localCrawler.queueURL("/timeout");
+            localCrawler.queueURL("/timeout2");
+
+            localCrawler.on("fetchstart", function() {
+
+                // If we haven't been called previously
+                if (!fetchStartCallCount) {
+                    return fetchStartCallCount++;
+                }
+
+                localCrawler._openRequests.length.should.equal(2,
+                    "The number of open requests should equal 2");
+
+                localCrawler._openRequests.forEach(function(req) {
+                    req.abort = function() {
+                        abortCallCount++;
+                    };
+                });
+
+                localCrawler.stop(true);
+                abortCallCount.should.equal(2,
+                    "The number of calls to req.abort() should equal 2");
+                done();
+            });
+        });
     });
 });

--- a/test/reliability.js
+++ b/test/reliability.js
@@ -162,7 +162,7 @@ describe("Crawler reliability", function() {
     describe("when stopping the crawler", function() {
 
         it("should not terminate open connections unless asked", function(done) {
-            var localCrawler = Crawler.crawl("http://127.0.0.1:3000/");
+            var localCrawler = new Crawler("http://127.0.0.1:3000/");
             var fetchStartCallCount = 0;
 
             // Speed things up
@@ -189,10 +189,12 @@ describe("Crawler reliability", function() {
                 localCrawler.stop();
                 done();
             });
+
+            localCrawler.start();
         });
 
         it("should terminate open connections when requested", function(done) {
-            var localCrawler = Crawler.crawl("http://127.0.0.1:3000/");
+            var localCrawler = new Crawler("http://127.0.0.1:3000/");
             var fetchStartCallCount = 0,
                 abortCallCount = 0;
 
@@ -225,6 +227,8 @@ describe("Crawler reliability", function() {
                     "The number of calls to req.abort() should equal 2");
                 done();
             });
+
+            localCrawler.start();
         });
     });
 });


### PR DESCRIPTION
##### PR Checklist

- [x] I have read and/or are familiar with the contributor guidelines
- [x] I have checked to make sure no existing PRs already satisfy the original requirements of this PR
- [x] The commit messages in this PR are clear, and any WIP commits have been squashed
- [x] The code passes lint checking
- [x] The PR contains no spelling or grammatical errors
- [x] Any relevant documentation has been updated
- [x] I have included tests for my code

---

Fixes #206.

* Added an additional boolean parameter on the call to stop(), which, if called, will forcibly terminate all in-flight requests.
* Requests are stored in the crawler on crawler._openRequests.
* When a request is complete, it is removed from the request array. This logic is repetitious and could stand to do with some consolidation.
* Calling crawler.stop(true) will loop over this request array and calls request.abort() on each.
* The 'fetchstart' event was moved so it would fire after the request initialisation process. Whether this is a good idea or not is up for debate.
* Tests were added.

### Notes

This code could really break crawler operation, and to be honest, I'm not feeling that confident about it. Going over it with a fine-toothed come would be very wise.