### PR TITLE
Deprecate initialProtocol, initialPath and initialPort

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ var Crawler = require("simplecrawler");
 var crawler = new Crawler("http://www.example.com/");
 ```
 
-You can initialise the crawler with or without the `new` operator. Being able to
+You can initialize the crawler with or without the `new` operator. Being able to
 skip it comes in handy when you want to chain API calls.
 
 ```js
@@ -73,26 +73,14 @@ var crawler = Crawler("http://www.example.com/")
     });
 ```
 
-The protocol and host that are used throughout the entire crawl are inferred
-from the start URL that's passed to the constructor. These properties, along
-with the initial path and port can also be set directly, however. So these two
-examples do the same thing:
+By default, the crawler will only fetch resources on the same domain as that in
+the URL passed to the constructor. But this can be changed through the
+`crawler.domainWhitelist` property.
 
-```js
-var crawler = new Crawler("https://www.example.com:8080/archive");
-```
-
-```js
-var crawler = new Crawler("http://www.example.com");
-
-crawler.initialPath = "/archive";
-crawler.initialPort = 8080;
-crawler.initialProtocol = "https";
-```
-
-Of course, you're probably wanting to ensure you don't take down your web
-server. Decrease the concurrency from five simultaneous requests - and increase
-the request interval from the default 250 ms like this:
+Now, let's configure some more things before we start crawling. Of course,
+you're probably wanting to ensure you don't take down your web server. Decrease
+the concurrency from five simultaneous requests - and increase the request
+interval from the default 250 ms like this:
 
 ```js
 crawler.interval = 10000; // Ten seconds
@@ -234,15 +222,6 @@ change to adapt it to your specific needs.
 * `crawler.host` -
     The domain to scan. By default, simplecrawler will restrict all requests to
     this domain.
-* `crawler.initialPath="/"` -
-    The initial path with which the crawler will formulate its first request.
-    Does not restrict subsequent requests.
-* `crawler.initialPort=80` -
-    The initial port with which the crawler will formulate its first request.
-    Does not restrict subsequent requests.
-* `crawler.initialProtocol="http"` -
-    The initial protocol with which the crawler will formulate its first
-    request. Does not restrict subsequent requests.
 * `crawler.interval=250` -
     The interval with which the crawler will spool up new requests (one per
     tick).

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -42,9 +42,6 @@ var Crawler = function(initialURL) {
         return new Crawler(initialURL);
     }
 
-    var crawler = this,
-        parsedURL = uri(initialURL).normalize();
-
     if (arguments.length > 1) {
         throw new Error("Since 1.0.0, simplecrawler takes a single URL when initialized. Protocol, hostname, port and path are inferred from that argument.");
     }
@@ -53,10 +50,11 @@ var Crawler = function(initialURL) {
         throw new Error("The crawler needs a URL string to know where to start crawling");
     }
 
-    crawler.host            = parsedURL.hostname();
-    crawler.initialPath     = parsedURL.pathname();
-    crawler.initialPort     = parsedURL.port();
-    crawler.initialProtocol = parsedURL.protocol();
+    var crawler = this,
+        parsedURL = uri(initialURL).normalize();
+
+    crawler.initialURL = initialURL;
+    crawler.host = parsedURL.hostname();
 
     // Internal 'tick' interval for spawning new requests
     // (as long as concurrency is under cap)
@@ -281,21 +279,13 @@ Crawler.prototype.start = function() {
         return crawler;
     }
 
-    // only if we haven't already got stuff in our queue...
-    crawler.queue.getLength(function(err, length) {
-        if (err) {
-            throw err;
+    crawler.queue.getLength(function(error, length) {
+        if (error) {
+            throw error;
         }
 
         if (!length) {
-            var initialUrl = uri({
-                protocol: crawler.initialProtocol,
-                hostname: crawler.host,
-                port: crawler.initialPort,
-                path: crawler.initialPath
-            }).href();
-
-            var queueItem = crawler.processURL(initialUrl);
+            var queueItem = crawler.processURL(crawler.initialURL);
             queueItem.referrer = undefined;
             queueItem.depth = QUEUE_ITEM_INITIAL_DEPTH;
 
@@ -307,18 +297,15 @@ Crawler.prototype.start = function() {
         }
 
         process.nextTick(function() {
-            crawler.crawlIntervalID = setInterval(function() {
-                crawler.crawl(crawler);
-            }, crawler.interval);
+            crawler.crawlIntervalID = setInterval(crawler.crawl.bind(crawler),
+                crawler.interval);
 
-            // Now kick off the initial crawl
             crawler.crawl();
         });
 
         crawler.running = true;
         crawler.emit("crawlstart");
     });
-
 
     return crawler;
 };
@@ -660,15 +647,8 @@ Crawler.prototype.processURL = function(url, referrer) {
         crawler = this;
 
     if (typeof referrer !== "object") {
-        var initialUrl = uri({
-            protocol: crawler.initialProtocol,
-            hostname: crawler.host,
-            port: crawler.initialPort,
-            path: crawler.initialPath
-        }).href();
-
         referrer = {
-            url: initialUrl,
+            url: crawler.initialURL,
             depth: QUEUE_ITEM_INITIAL_DEPTH
         };
     }


### PR DESCRIPTION
### PR Checklist

- [x] I have read and/or are familiar with the contributor guidelines
- [x] I have checked to make sure no existing PRs already satisfy the original requirements of this PR
- [x] The commit messages in this PR are clear, and any WIP commits have been squashed
- [x] The code passes lint checking
- [x] The PR contains no spelling or grammatical errors
- [x] Any relevant documentation has been updated
- [x] I have included tests for my code

### What this PR changes
Removes `initialProtocol`, `initialPort` and `initialPath` properties.

### Rationale
They were in fact only being used to construct an initialURL, which is now passed to the constructor in its entirety. It would make more sense to simply remove these properties than to keep them around.