### PR TITLE
Fix race-condition causing incomplete crawls

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -240,7 +240,8 @@ var Crawler = function(initialURL) {
         _isFirstRequest: true,
         _openRequests: [],
         _fetchConditions: [],
-        _openListeners: 0
+        _openListeners: 0,
+        _openDiscoveries: 0
     };
 
     // Run the EventEmitter constructor
@@ -1232,6 +1233,8 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
         if (crawler.mimeTypeSupported(contentType) && crawler.discoverResources) {
             crawler.queueLinkedItems(decompressedBuffer || responseBody, queueItem);
         }
+
+        crawler._openDiscoveries--;
     }
 
     // Function for dealing with 200 responses
@@ -1260,6 +1263,8 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
         }
 
         if (crawler.depthAllowed(queueItem)) {
+            crawler._openDiscoveries++;
+
             // No matter the value of `crawler.decompressResponses`, we still
             // decompress the response if it's gzipped or deflated. This is
             // because we always provide the discoverResources method with a
@@ -1496,7 +1501,7 @@ Crawler.prototype.crawl = function() {
 
                 crawler.fetchQueueItem(queueItem);
             }
-        } else if (!crawler._openRequests.length && !crawler._openListeners) {
+        } else if (!crawler._openRequests.length && !crawler._openListeners && !crawler._openDiscoveries) {
 
             crawler.queue.countItems({ fetched: true }, function (err, completeCount) {
                 if (err) {


### PR DESCRIPTION
### PR Checklist

- [x] I have read and/or are familiar with the contributor guidelines
- [x] I have checked to make sure no existing PRs already satisfy the original requirements of this PR
- [x] The commit messages in this PR are clear, and any WIP commits have been squashed
- [x] The code passes lint checking
- [x] The PR contains no spelling or grammatical errors
- [x] Any relevant documentation has been updated
- [ ] I have included tests for my code

### What this PR changes

### Rationale
Fixes #298

When the combination of number of items and fetch time was high enough
(when compared to the crawler's crawl interval), the crawler could stop
crawling before processing the discovery phase (in which the items would
be discovered from the latest fetched page).

This commit adds a new counter `_openDiscoveries` that works similarly
to the already existing logic for `_openRequests` and `_openListeners`.
With this, if a `crawl()` is reached while items are still being
discovered (given by `_openDiscoveries`, which is updated on fetch if
the crawl depth is suitable), the crawler will not stop.