### PR TITLE
Only update queue items asynchronously

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -281,6 +281,8 @@ Crawler.prototype.start = function() {
         return crawler;
     }
 
+    crawler.running = true;
+
     // only if we haven't already got stuff in our queue...
     crawler.queue.getLength(function(err, length) {
         if (err) {
@@ -303,22 +305,20 @@ Crawler.prototype.start = function() {
                 if (error) {
                     throw error;
                 }
+
+                process.nextTick(function() {
+                    crawler.crawlIntervalID = setInterval(function() {
+                        crawler.crawl(crawler);
+                    }, crawler.interval);
+
+                    // Now kick off the initial crawl
+                    crawler.crawl();
+                });
+
+                crawler.emit("crawlstart");
             });
         }
-
-        process.nextTick(function() {
-            crawler.crawlIntervalID = setInterval(function() {
-                crawler.crawl(crawler);
-            }, crawler.interval);
-
-            // Now kick off the initial crawl
-            crawler.crawl();
-        });
-
-        crawler.running = true;
-        crawler.emit("crawlstart");
     });
-
 
     return crawler;
 };

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -1062,98 +1062,97 @@ Crawler.prototype.queueURL = function(url, referrer) {
 
 */
 Crawler.prototype.fetchQueueItem = function(queueItem) {
-    var crawler = this;
+    var crawler = this,
+        timeCommenced = Date.now();
 
-    // Variable declarations
-    var clientRequest,
-        timeCommenced;
+    crawler.queue.update(queueItem.url, {
+        status: "spooled"
+    }, function(error, queueItem) {
+        var client = queueItem.protocol === "https" ? https : http;
+        var agent  = queueItem.protocol === "https" ? crawler.httpsAgent : crawler.httpAgent;
 
-    // Mark as spooled
-    queueItem.status = "spooled";
-    var client = queueItem.protocol === "https" ? https : http;
-    var agent  = queueItem.protocol === "https" ? crawler.httpsAgent : crawler.httpAgent;
+        if (agent.maxSockets < crawler.maxConcurrency) {
+            agent.maxSockets = crawler.maxConcurrency;
+        }
 
-    // Up the socket limit if required.
-    if (agent.maxSockets < crawler.maxConcurrency) {
-        agent.maxSockets = crawler.maxConcurrency;
-    }
+        if (client === https && crawler.ignoreInvalidSSL === true) {
+            client.rejectUnauthorized = false;
+            client.strictSSL = false;
+        }
 
-    // Apply the ignoreInvalidSSL setting to https connections
-    if (client === https && crawler.ignoreInvalidSSL === true) {
-        client.rejectUnauthorized = false;
-        client.strictSSL = false;
-    }
-
-    var requestOptions = crawler.getRequestOptions(queueItem);
-
-    // Record what time we started this request
-    timeCommenced = Date.now();
-
-    // Get the resource!
-    clientRequest =
-        client.request(requestOptions, function(response) {
+        var requestOptions = crawler.getRequestOptions(queueItem);
+        var clientRequest = client.request(requestOptions, function(response) {
             crawler.handleResponse(queueItem, response, timeCommenced);
         });
 
-    clientRequest.end();
+        clientRequest.end();
 
-    // Enable central tracking of this request
-    crawler._openRequests.push(clientRequest);
+        // Enable central tracking of this request
+        crawler._openRequests.push(clientRequest);
 
-    // Ensure the request is removed from the tracking array if it is
-    // forcibly aborted
-    clientRequest.on("abort", function() {
-        if (crawler._openRequests.indexOf(clientRequest) > -1) {
-            crawler._openRequests.splice(
-                crawler._openRequests.indexOf(clientRequest), 1);
-        }
+        // Ensure the request is removed from the tracking array if it is
+        // forcibly aborted
+        clientRequest.on("abort", function() {
+            if (crawler._openRequests.indexOf(clientRequest) > -1) {
+                crawler._openRequests.splice(
+                    crawler._openRequests.indexOf(clientRequest), 1);
+            }
+        });
+
+        clientRequest.setTimeout(crawler.timeout, function() {
+            if (queueItem.fetched) {
+                return;
+            }
+
+            if (crawler.running && !queueItem.fetched) {
+                // Remove this request from the open request map
+                crawler._openRequests.splice(
+                    crawler._openRequests.indexOf(clientRequest), 1);
+            }
+
+            crawler.queue.update(queueItem.url, {
+                fetched: true,
+                status: "timeout"
+            }, function(error, queueItem) {
+                crawler.emit("fetchtimeout", queueItem, crawler.timeout);
+                clientRequest._crawlerHandled = true;
+                clientRequest.abort();
+            });
+        });
+
+        clientRequest.on("error", function(errorData) {
+
+            // This event will be thrown if we manually aborted the request,
+            // but we don't want to do anything in that case.
+            if (clientRequest._crawlerHandled) {
+                return;
+            }
+
+            if (crawler.running && !queueItem.fetched) {
+                // Remove this request from the open request map
+                crawler._openRequests.splice(
+                    crawler._openRequests.indexOf(clientRequest), 1);
+            }
+
+            crawler.queue.update(queueItem.url, {
+                fetched: true,
+                status: "failed",
+                stateData: {
+                    code: 600
+                }
+            }, function(error, queueItem) {
+                // Emit 5xx / 4xx event
+                crawler.emit("fetchclienterror", queueItem, errorData);
+            });
+        });
+
+        // Emit fetchstart event once everything about the request has been
+        // established.
+        //
+        // This code previously relied on a side-effect to enable per-request
+        // mangling of the request options, but that was probably not a good idea.
+        crawler.emit("fetchstart", queueItem, requestOptions);
     });
-
-    clientRequest.setTimeout(crawler.timeout, function() {
-        if (queueItem.fetched) {
-            return;
-        }
-
-        if (crawler.running && !queueItem.fetched) {
-            // Remove this request from the open request map
-            crawler._openRequests.splice(
-                crawler._openRequests.indexOf(clientRequest), 1);
-        }
-
-        queueItem.fetched = true;
-        queueItem.status = "timeout";
-        crawler.emit("fetchtimeout", queueItem, crawler.timeout);
-        clientRequest._crawlerHandled = true;
-        clientRequest.abort();
-    });
-
-    clientRequest.on("error", function(errorData) {
-
-        // This event will be thrown if we manually aborted the request,
-        // but we don't want to do anything in that case.
-        if (clientRequest._crawlerHandled) {
-            return;
-        }
-
-        if (crawler.running && !queueItem.fetched) {
-            // Remove this request from the open request map
-            crawler._openRequests.splice(
-                crawler._openRequests.indexOf(clientRequest), 1);
-        }
-
-        // Emit 5xx / 4xx event
-        queueItem.fetched = true;
-        queueItem.stateData.code = 600;
-        queueItem.status = "failed";
-        crawler.emit("fetchclienterror", queueItem, errorData);
-    });
-
-    // Emit fetchstart event once everything about the request has been
-    // established.
-    //
-    // This code previously relied on a side-effect to enable per-request
-    // mangling of the request options, but that was probably not a good idea.
-    crawler.emit("fetchstart", queueItem, requestOptions);
 
     return crawler;
 };
@@ -1201,254 +1200,276 @@ Crawler.prototype.decodeBuffer = function (buffer, contentTypeHeader) {
 Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) {
     var crawler = this,
         dataReceived = false,
-        timeHeadersReceived,
+        timeHeadersReceived = Date.now(),
         timeDataReceived,
-        referrerQueueItem,
         responseBuffer,
         responseLength,
         responseLengthReceived = 0,
-        contentType,
-        stateData = queueItem.stateData;
+        contentType = response.headers["content-type"];
 
-    // Record what time we first received the header information
-    timeHeadersReceived = Date.now();
-
-    // If we weren't passed a time of commencement, assume Now()
     timeCommenced = timeCommenced || Date.now();
-
     responseLength = parseInt(response.headers["content-length"], 10);
     responseLength = !isNaN(responseLength) ? responseLength : 0;
 
-    // Save timing and content some header information into queue
-    stateData.requestLatency = timeHeadersReceived - timeCommenced;
-    stateData.requestTime    = timeHeadersReceived - timeCommenced;
-    stateData.contentLength  = responseLength;
-    stateData.contentType    = contentType = response.headers["content-type"];
-    stateData.code           = response.statusCode;
-    stateData.headers        = response.headers;
 
-    // Do we need to save cookies? Were we sent any?
-    if (crawler.acceptCookies && response.headers.hasOwnProperty("set-cookie")) {
-        try {
-            crawler.cookies.addFromHeaders(response.headers["set-cookie"]);
-        } catch (error) {
-            crawler.emit("cookieerror", queueItem, error, response.headers["set-cookie"]);
+    crawler.queue.update(queueItem.url, {
+        stateData: {
+            requestLatency: timeHeadersReceived - timeCommenced,
+            requestTime: timeHeadersReceived - timeCommenced,
+            contentLength: responseLength,
+            contentType: contentType,
+            code: response.statusCode,
+            headers: response.headers
         }
-    }
-
-    // Emit header receive event
-    crawler.emit("fetchheaders", queueItem, response);
-
-    // Ensure response length is reasonable...
-    responseLength = responseLength > 0 ? responseLength : crawler.maxResourceSize;
-    queueItem.stateData.contentLength = responseLength;
-
-    function emitFetchComplete(responseBody, decompressedBuffer) {
-        responseBody = crawler.decodeResponses ? crawler.decodeBuffer(responseBody, stateData.contentType) : responseBody;
-        crawler.emit("fetchcomplete", queueItem, responseBody, response);
-
-        // We only process the item if it's of a valid mimetype
-        // and only if the crawler is set to discover its own resources
-        if (crawler.mimeTypeSupported(contentType) && crawler.discoverResources) {
-            crawler.queueLinkedItems(decompressedBuffer || responseBody, queueItem);
-        }
-    }
-
-    // Function for dealing with 200 responses
-    function processReceivedData() {
-        if (dataReceived || queueItem.fetched) {
-            return;
-        }
-
-        responseBuffer = responseBuffer.slice(0, responseLengthReceived);
-        dataReceived = true;
-
-        timeDataReceived = new Date().getTime();
-
-        queueItem.fetched = true;
-        queueItem.status = "downloaded";
-
-        // Save state information
-        stateData.downloadTime      = timeDataReceived - timeHeadersReceived;
-        stateData.requestTime       = timeDataReceived - timeCommenced;
-        stateData.actualDataSize    = responseBuffer.length;
-        stateData.sentIncorrectSize = responseBuffer.length !== responseLength;
-
-        // First, save item to cache (if we're using a cache!)
-        if (crawler.cache !== null && crawler.cache.setCacheData instanceof Function) {
-            crawler.cache.setCacheData(queueItem, responseBuffer);
-        }
-
-        if (crawler.depthAllowed(queueItem)) {
-            // No matter the value of `crawler.decompressResponses`, we still
-            // decompress the response if it's gzipped or deflated. This is
-            // because we always provide the discoverResources method with a
-            // decompressed buffer
-            if (/(gzip|deflate)/.test(stateData.headers["content-encoding"])) {
-                zlib.unzip(responseBuffer, function(error, decompressedBuffer) {
-                    if (error) {
-                        crawler.emit("gziperror", queueItem, error, responseBuffer);
-                        emitFetchComplete(responseBuffer);
-                    } else {
-                        var responseBody = crawler.decompressResponses ? decompressedBuffer : responseBuffer;
-                        emitFetchComplete(responseBody, decompressedBuffer);
-                    }
-                });
-            } else {
-                emitFetchComplete(responseBuffer);
+    }, function(error, queueItem) {
+        // Do we need to save cookies? Were we sent any?
+        if (crawler.acceptCookies && response.headers.hasOwnProperty("set-cookie")) {
+            try {
+                crawler.cookies.addFromHeaders(response.headers["set-cookie"]);
+            } catch (error) {
+                crawler.emit("cookieerror", queueItem, error, response.headers["set-cookie"]);
             }
         }
 
-        // Remove this request from the open request map
-        crawler._openRequests.splice(
-            crawler._openRequests.indexOf(response.req), 1);
-    }
+        // Emit header receive event
+        crawler.emit("fetchheaders", queueItem, response);
 
-    function receiveData(chunk) {
-        if (!chunk.length || dataReceived) {
-            return;
-        }
+        // We already know that the response will be too big
+        if (responseLength > crawler.maxResourceSize) {
 
-        if (responseLengthReceived + chunk.length > responseBuffer.length) {
-            // Oh dear. We've been sent more data than we were initially told.
-            // This could be a mis-calculation, or a streaming resource.
-            // Let's increase the size of our buffer to match, as long as it isn't
-            // larger than our maximum resource size.
+            crawler.queue.update(queueItem.url, {
+                fetched: true
+            }, function(error, queueItem) {
+                // Remove this request from the open request map
+                crawler._openRequests.splice(
+                    crawler._openRequests.indexOf(response.req), 1);
 
-            if (responseLengthReceived + chunk.length <= crawler.maxResourceSize) {
-
-                // Create a temporary buffer with the new response length, copy
-                // the old data into it and replace the old buffer with it
-                var tmpNewBuffer = new Buffer(responseLengthReceived + chunk.length);
-                responseBuffer.copy(tmpNewBuffer, 0, 0, responseBuffer.length);
-                chunk.copy(tmpNewBuffer, responseBuffer.length, 0, chunk.length);
-                responseBuffer = tmpNewBuffer;
-            } else {
-
-                // The response size exceeds maxResourceSize. Throw event and
-                // ignore. We'll then deal with the data that we have.
                 response.socket.destroy();
                 crawler.emit("fetchdataerror", queueItem, response);
-            }
-        } else {
-            chunk.copy(responseBuffer, responseLengthReceived, 0, chunk.length);
-        }
-
-        responseLengthReceived += chunk.length;
-    }
-
-    // We already know that the response will be too big
-    if (responseLength > crawler.maxResourceSize) {
-        queueItem.fetched = true;
-
-        // Remove this request from the open request map
-        crawler._openRequests.splice(
-            crawler._openRequests.indexOf(response.req), 1);
-
-        response.socket.destroy();
-        crawler.emit("fetchdataerror", queueItem, response);
-
-    // We should just go ahead and get the data
-    } else if (response.statusCode >= 200 && response.statusCode < 300) {
-
-        queueItem.status = "headers";
-
-        // Create a buffer with our response length
-        responseBuffer = new Buffer(responseLength);
-
-        // Only if we're prepared to download non-text resources...
-        if (crawler.downloadUnsupported ||
-            crawler.mimeTypeSupported(contentType)) {
-
-            response.on("data", receiveData);
-            response.on("end", processReceivedData);
-        } else {
-            queueItem.fetched = true;
-
-            // Remove this request from the open request map
-            crawler._openRequests.splice(
-                crawler._openRequests.indexOf(response.req), 1);
-
-            response.socket.destroy();
-        }
-
-        crawler._isFirstRequest = false;
-
-    // We've got a not-modified response back
-    } else if (response.statusCode === 304) {
-
-        if (crawler.cache !== null && crawler.cache.getCacheData) {
-            // We've got access to a cache
-            crawler.cache.getCacheData(queueItem, function(cacheObject) {
-                crawler.emit("notmodified", queueItem, response, cacheObject);
             });
+
+                // We should just go ahead and get the data
+        } else if (response.statusCode >= 200 && response.statusCode < 300) {
+
+            crawler.queue.update(queueItem.url, {
+                status: "headers"
+            }, function() {
+                // Create a buffer with our response length
+                responseBuffer = new Buffer(responseLength);
+
+                // Only if we're prepared to download non-text resources...
+                if (crawler.downloadUnsupported || crawler.mimeTypeSupported(contentType)) {
+                    response.on("data", receiveData);
+                    response.on("end", processReceivedData);
+                } else {
+
+                    crawler.queue.update(queueItem.url, {
+                        fetched: true
+                    }, function() {
+                        // Remove this request from the open request map
+                        crawler._openRequests.splice(
+                            crawler._openRequests.indexOf(response.req), 1);
+
+                        response.socket.destroy();
+                    });
+                }
+
+                crawler._isFirstRequest = false;
+            });
+
+        // We've got a not-modified response back
+        } else if (response.statusCode === 304) {
+
+            if (crawler.cache !== null && crawler.cache.getCacheData) {
+                // We've got access to a cache
+                crawler.cache.getCacheData(queueItem, function(cacheObject) {
+                    crawler.emit("notmodified", queueItem, response, cacheObject);
+                });
+            } else {
+                // Emit notmodified event. We don't have a cache available, so
+                // we don't send any data.
+                crawler.emit("notmodified", queueItem, response);
+            }
+
+            crawler._isFirstRequest = false;
+
+            // If we should queue a redirect
+        } else if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
+
+            crawler.queue.update(queueItem.url, {
+                fetched: true,
+                status: "redirected"
+            }, function(error, queueItem) {
+
+                var referrerQueueItem = crawler.processURL(response.headers.location, queueItem);
+
+                if (crawler._isFirstRequest) {
+                    referrerQueueItem.depth = QUEUE_ITEM_INITIAL_DEPTH;
+                }
+
+                // Emit redirect event
+                crawler.emit("fetchredirect", queueItem, referrerQueueItem, response);
+
+                if (crawler.allowInitialDomainChange && crawler._isFirstRequest) {
+                    crawler.host = referrerQueueItem.host;
+                }
+
+                // Clean URL, add to queue...
+                crawler.queueURL(referrerQueueItem, queueItem);
+                response.socket.destroy();
+
+                // Remove this request from the open request map
+                crawler._openRequests.splice(
+                    crawler._openRequests.indexOf(response.req), 1);
+            });
+
+            // Ignore this request, but record that we had a 404
+        } else if (response.statusCode === 404 || response.statusCode === 410) {
+
+            crawler.queue.update(queueItem.url, {
+                fetched: true,
+                status: "notfound"
+            }, function(error, queueItem) {
+                // Emit 404 event
+                crawler.emit("fetch" + response.statusCode, queueItem, response);
+                response.socket.destroy();
+
+                // Remove this request from the open request map
+                crawler._openRequests.splice(
+                    crawler._openRequests.indexOf(response.req), 1);
+
+                crawler._isFirstRequest = false;
+            });
+
+            // And oh dear. Handle this one as well. (other 400s, 500s, etc)
         } else {
-            // Emit notmodified event. We don't have a cache available, so
-            // we don't send any data.
-            crawler.emit("notmodified", queueItem, response);
+
+            crawler.queue.update(queueItem.url, {
+                fetched: true,
+                status: "failed"
+            }, function(error, queueItem) {
+                // Emit 5xx / 4xx event
+                crawler.emit("fetcherror", queueItem, response);
+                response.socket.destroy();
+
+                // Remove this request from the open request map
+                crawler._openRequests.splice(
+                    crawler._openRequests.indexOf(response.req), 1);
+
+                crawler._isFirstRequest = false;
+            });
+
         }
 
-        crawler._isFirstRequest = false;
 
-    // If we should queue a redirect
-    } else if (response.statusCode >= 300 && response.statusCode < 400 &&
-                    response.headers.location) {
+        function emitFetchComplete(responseBody, decompressedBuffer) {
+            if (crawler.decodeResponses) {
+                responseBody = crawler.decodeBuffer(responseBody, queueItem.stateData.contentType);
+            }
 
-        queueItem.fetched = true;
-        queueItem.status = "redirected";
+            crawler.emit("fetchcomplete", queueItem, responseBody, response);
 
-        // Parse the redirect URL ready for adding to the queue...
-        referrerQueueItem = crawler.processURL(response.headers.location, queueItem);
-
-        // Emit redirect event
-        crawler.emit("fetchredirect", queueItem, referrerQueueItem, response);
-
-        if (crawler._isFirstRequest) {
-            referrerQueueItem.depth = 1;
+            // We only process the item if it's of a valid mimetype
+            // and only if the crawler is set to discover its own resources
+            if (crawler.mimeTypeSupported(contentType) && crawler.discoverResources) {
+                crawler.queueLinkedItems(decompressedBuffer || responseBody, queueItem);
+            }
         }
 
-        if (crawler.allowInitialDomainChange && crawler._isFirstRequest) {
-            crawler.host = referrerQueueItem.host;
+        // Function for dealing with 200 responses
+        function processReceivedData() {
+            if (dataReceived || queueItem.fetched) {
+                return;
+            }
+
+            responseBuffer = responseBuffer.slice(0, responseLengthReceived);
+            dataReceived = true;
+            timeDataReceived = Date.now();
+
+            crawler.queue.update(queueItem.url, {
+                fetched: true,
+                status: "downloaded",
+                stateData: {
+                    downloadTime: timeDataReceived - timeHeadersReceived,
+                    requestTime: timeDataReceived - timeCommenced,
+                    actualDataSize: responseBuffer.length,
+                    sentIncorrectSize: responseBuffer.length !== responseLength
+                }
+            }, function (error, queueItem) {
+                if (error) {
+                    // Remove this request from the open request map
+                    crawler._openRequests.splice(
+                        crawler._openRequests.indexOf(response.req), 1);
+
+                    throw error;
+                }
+
+                // First, save item to cache (if we're using a cache!)
+                if (crawler.cache && crawler.cache.setCacheData instanceof Function) {
+                    crawler.cache.setCacheData(queueItem, responseBuffer);
+                }
+
+                if (crawler.depthAllowed(queueItem)) {
+                    // No matter the value of `crawler.decompressResponses`, we still
+                    // decompress the response if it's gzipped or deflated. This is
+                    // because we always provide the discoverResources method with a
+                    // decompressed buffer
+                    if (/(gzip|deflate)/.test(queueItem.stateData.headers["content-encoding"])) {
+                        zlib.unzip(responseBuffer, function(error, decompressedBuffer) {
+                            if (error) {
+                                crawler.emit("gziperror", queueItem, error, responseBuffer);
+                                emitFetchComplete(responseBuffer);
+                            } else {
+                                var responseBody = crawler.decompressResponses ? decompressedBuffer : responseBuffer;
+                                emitFetchComplete(responseBody, decompressedBuffer);
+                            }
+                        });
+                    } else {
+                        emitFetchComplete(responseBuffer);
+                    }
+                }
+
+                // Remove this request from the open request map
+                crawler._openRequests.splice(
+                    crawler._openRequests.indexOf(response.req), 1);
+            });
+
         }
 
-        // Clean URL, add to queue...
-        crawler.queueURL(referrerQueueItem, queueItem);
-        response.socket.destroy();
+        function receiveData(chunk) {
+            if (!chunk.length || dataReceived) {
+                return;
+            }
 
-        // Remove this request from the open request map
-        crawler._openRequests.splice(
-            crawler._openRequests.indexOf(response.req), 1);
+            if (responseLengthReceived + chunk.length > responseBuffer.length) {
 
-    // Ignore this request, but record that we had a 404
-    } else if (response.statusCode === 404 || response.statusCode === 410) {
-        queueItem.fetched = true;
-        queueItem.status = "notfound";
+                // Oh dear. We've been sent more data than we were initially told.
+                // This could be a mis-calculation, or a streaming resource.
+                // Let's increase the size of our buffer to match, as long as it isn't
+                // larger than our maximum resource size.
+                if (responseLengthReceived + chunk.length <= crawler.maxResourceSize) {
 
-        // Emit 404 event
-        crawler.emit("fetch" + response.statusCode, queueItem, response);
-        response.socket.destroy();
+                    // Create a temporary buffer with the new response length, copy
+                    // the old data into it and replace the old buffer with it
+                    var tmpNewBuffer = new Buffer(responseLengthReceived + chunk.length);
+                    responseBuffer.copy(tmpNewBuffer, 0, 0, responseBuffer.length);
+                    chunk.copy(tmpNewBuffer, responseBuffer.length, 0, chunk.length);
+                    responseBuffer = tmpNewBuffer;
+                } else {
 
-        // Remove this request from the open request map
-        crawler._openRequests.splice(
-            crawler._openRequests.indexOf(response.req), 1);
+                    // The response size exceeds maxResourceSize. Throw event and
+                    // ignore. We'll then deal with the data that we have.
+                    response.socket.destroy();
+                    crawler.emit("fetchdataerror", queueItem, response);
+                }
+            } else {
+                chunk.copy(responseBuffer, responseLengthReceived, 0, chunk.length);
+            }
 
-        crawler._isFirstRequest = false;
+            responseLengthReceived += chunk.length;
+        }
+    });
 
-    // And oh dear. Handle this one as well. (other 400s, 500s, etc)
-    } else {
-        queueItem.fetched = true;
-        queueItem.status = "failed";
-
-        // Emit 5xx / 4xx event
-        crawler.emit("fetcherror", queueItem, response);
-        response.socket.destroy();
-
-        // Remove this request from the open request map
-        crawler._openRequests.splice(
-            crawler._openRequests.indexOf(response.req), 1);
-
-        crawler._isFirstRequest = false;
-    }
 
     return crawler;
 };
@@ -1507,9 +1528,12 @@ Crawler.prototype.crawl = function() {
                     if (crawler.urlIsAllowed(queueItem.url)) {
                         crawler.fetchQueueItem(queueItem);
                     } else {
-                        queueItem.fetched = true;
-                        queueItem.status = "disallowed";
-                        crawler.emit("fetchdisallowed", queueItem);
+                        crawler.queue.update(queueItem.url, {
+                            fetched: true,
+                            status: "disallowed"
+                        }, function(error, queueItem) {
+                            crawler.emit("fetchdisallowed", queueItem);
+                        });
                     }
                 });
             } else {

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -1068,6 +1068,10 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
     crawler.queue.update(queueItem.url, {
         status: "spooled"
     }, function(error, queueItem) {
+        if (error) {
+            return crawler.emit("queueerror", error, queueItem);
+        }
+
         var client = queueItem.protocol === "https" ? https : http;
         var agent  = queueItem.protocol === "https" ? crawler.httpsAgent : crawler.httpAgent;
 
@@ -1114,6 +1118,10 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
                 fetched: true,
                 status: "timeout"
             }, function(error, queueItem) {
+                if (error) {
+                    return crawler.emit("queueerror", error, queueItem);
+                }
+
                 crawler.emit("fetchtimeout", queueItem, crawler.timeout);
                 clientRequest._crawlerHandled = true;
                 clientRequest.abort();
@@ -1141,6 +1149,10 @@ Crawler.prototype.fetchQueueItem = function(queueItem) {
                     code: 600
                 }
             }, function(error, queueItem) {
+                if (error) {
+                    return crawler.emit("queueerror", error, queueItem);
+                }
+
                 // Emit 5xx / 4xx event
                 crawler.emit("fetchclienterror", queueItem, errorData);
             });
@@ -1222,6 +1234,10 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
             headers: response.headers
         }
     }, function(error, queueItem) {
+        if (error) {
+            return crawler.emit("queueerror", error, queueItem);
+        }
+
         // Do we need to save cookies? Were we sent any?
         if (crawler.acceptCookies && response.headers.hasOwnProperty("set-cookie")) {
             try {
@@ -1240,6 +1256,10 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
             crawler.queue.update(queueItem.url, {
                 fetched: true
             }, function(error, queueItem) {
+                if (error) {
+                    return crawler.emit("queueerror", error, queueItem);
+                }
+
                 // Remove this request from the open request map
                 crawler._openRequests.splice(
                     crawler._openRequests.indexOf(response.req), 1);
@@ -1253,7 +1273,11 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
 
             crawler.queue.update(queueItem.url, {
                 status: "headers"
-            }, function() {
+            }, function(error, queueItem) {
+                if (error) {
+                    return crawler.emit("queueerror", error, queueItem);
+                }
+
                 // Create a buffer with our response length
                 responseBuffer = new Buffer(responseLength);
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -23,7 +23,7 @@ function noop() {}
  * to the same properties in the second one and returns true if all of the
  * properties matched. If not, it returns false.
  */
-function compare (a, b) {
+function compare(a, b) {
     var matches;
 
     for (var key in a) {
@@ -39,6 +39,25 @@ function compare (a, b) {
     }
 
     return matches;
+}
+
+/**
+ * Recursive function that takes two objects and updates the properties on the
+ * first object based on the ones in the second. Basically, it's a recursive
+ * version of Object.assign.
+ */
+function deepAssign(object, source) {
+    for (var key in source) {
+        if (source.hasOwnProperty(key)) {
+            if (typeof object[key] === "object" && typeof source[key] === "object") {
+                deepAssign(object[key], source[key]);
+            } else {
+                object[key] = source[key];
+            }
+        }
+    }
+
+    return object;
 }
 
 var FetchQueue = function() {
@@ -105,6 +124,25 @@ FetchQueue.prototype.get = function(index, callback) {
             callback(null, queue[index]);
         }
     });
+};
+
+FetchQueue.prototype.update = function (url, updates, callback) {
+    var queue = this,
+        queueItem;
+
+    for (var i = 0; i < queue.length; i++) {
+        if (queue[i].url === url) {
+            queueItem = queue[i];
+            break;
+        }
+    }
+
+    if (!queueItem) {
+        callback(new Error("No queueItem found with that URL"));
+    } else {
+        deepAssign(queueItem, updates);
+        callback(null, queueItem);
+    }
 };
 
 // Get first unfetched item in the queue (and return its index)

--- a/test/queue.js
+++ b/test/queue.js
@@ -1,5 +1,4 @@
 /* eslint-env mocha */
-/* eslint eqeqeq: [1] */
 
 var chai = require("chai"),
     Crawler = require("../"),
@@ -7,12 +6,34 @@ var chai = require("chai"),
 
 var should = chai.should();
 
+function find(array, callback) {
+    for (var i = 0; i < array.length; i++) {
+        if (callback(array[i], i, array)) {
+            return array[i];
+        }
+    }
+}
+
+function deepAssign(object, source) {
+    for (var key in source) {
+        if (source.hasOwnProperty(key)) {
+            if (typeof object[key] === "object" && typeof source[key] === "object") {
+                deepAssign(object[key], source[key]);
+            } else {
+                object[key] = source[key];
+            }
+        }
+    }
+
+    return object;
+}
+
 describe("Queue methods", function() {
     var crawler = new Crawler("http://127.0.0.1:3000/");
 
     var addToQueue = function(done) {
         Object.keys(queue).forEach(function(key) {
-            if (Number(key) == key) {
+            if (!isNaN(parseInt(key, 10))) {
                 crawler.queueURL(queue[key].url);
             }
         });
@@ -187,5 +208,87 @@ describe("Queue methods", function() {
             should.not.exist(newQueueItem);
             checkDone();
         });
+    });
+
+    it("should update items in the queue", function(done) {
+        crawler.queue.update("http://127.0.0.1:3000/stage2", {
+            status: "queued",
+            fetched: false
+        }, function(error, queueItem) {
+            queueItem.should.include({
+                url: "http://127.0.0.1:3000/stage2",
+                status: "queued",
+                fetched: false
+            });
+
+            done(error);
+        });
+    });
+
+    /**
+     * This test works by monkey patching the queue `add` and `update` methods
+     * and keeping a local copy of the queue, which contains cloned queueItems.
+     * Each time the `update` method is called, we deeply compare the copy in
+     * the queue with our local one. Same thing when the crawler completes.
+     */
+    it("should only update queue items asynchronously", function(done) {
+        var crawler = new Crawler("http://127.0.0.1:3000"),
+            originalQueueAdd = crawler.queue.add,
+            originalQueueUpdate = crawler.queue.update;
+
+        var queueItems = [];
+
+        crawler.interval = 5;
+        crawler.maxDepth = 2;
+
+        function findByUrl(array, url) {
+            return find(array, function(queueItem) {
+                return queueItem.url === url;
+            });
+        }
+
+        crawler.queue.add = function (queueItem) {
+            var storedQueueItem = Object.assign({}, queueItem, {
+                status: "queued"
+            });
+            queueItems.push(storedQueueItem);
+
+            originalQueueAdd.apply(crawler.queue, arguments);
+        };
+
+        crawler.queue.update = function(url, updates) {
+            var storedQueueItem = findByUrl(queueItems, url),
+                queueQueueItem = findByUrl(crawler.queue, url);
+
+            queueQueueItem.should.eql(storedQueueItem);
+            deepAssign(storedQueueItem, updates);
+
+            originalQueueUpdate.apply(crawler.queue, arguments);
+        };
+
+        crawler.on("complete", function() {
+            crawler.queue.getLength(function(error, length) {
+                // Recursively step through items in the real queue and compare
+                // them to our local clones
+                function getItem(index) {
+                    crawler.queue.get(index, function(error, queueQueueItem) {
+                        var storedQueueItem = findByUrl(queueItems, queueQueueItem.url),
+                            nextIndex = index + 1;
+
+                        queueQueueItem.should.eql(storedQueueItem);
+
+                        if (nextIndex < length) {
+                            getItem(nextIndex);
+                        } else {
+                            done();
+                        }
+                    });
+                }
+
+                getItem(0);
+            });
+        });
+
+        crawler.start();
     });
 });

--- a/test/queue.js
+++ b/test/queue.js
@@ -248,21 +248,29 @@ describe("Queue methods", function() {
         }
 
         crawler.queue.add = function (queueItem) {
-            var storedQueueItem = deepAssign({}, queueItem);
-            storedQueueItem.status = "queued";
-            queueItems.push(storedQueueItem);
+            var args = arguments;
 
-            originalQueueAdd.apply(crawler.queue, arguments);
+            process.nextTick(function() {
+                var storedQueueItem = deepAssign({}, queueItem);
+                storedQueueItem.status = "queued";
+                queueItems.push(storedQueueItem);
+
+                originalQueueAdd.apply(crawler.queue, args);
+            });
         };
 
         crawler.queue.update = function(url, updates) {
-            var storedQueueItem = findByUrl(queueItems, url),
-                queueQueueItem = findByUrl(crawler.queue, url);
+            var args = arguments;
 
-            queueQueueItem.should.eql(storedQueueItem);
-            deepAssign(storedQueueItem, updates);
+            process.nextTick(function() {
+                var storedQueueItem = findByUrl(queueItems, url),
+                    queueQueueItem = findByUrl(crawler.queue, url);
 
-            originalQueueUpdate.apply(crawler.queue, arguments);
+                queueQueueItem.should.eql(storedQueueItem);
+                deepAssign(storedQueueItem, updates);
+
+                originalQueueUpdate.apply(crawler.queue, args);
+            });
         };
 
         crawler.on("complete", function() {

--- a/test/queue.js
+++ b/test/queue.js
@@ -322,6 +322,7 @@ describe("Queue methods", function() {
             queueItem.should.have.a.property("url");
             queueItem.should.have.a.property("fetched");
             queueItem.should.have.a.property("status");
+            crawler.stop(true);
             done();
         });
 

--- a/test/queue.js
+++ b/test/queue.js
@@ -248,9 +248,8 @@ describe("Queue methods", function() {
         }
 
         crawler.queue.add = function (queueItem) {
-            var storedQueueItem = Object.assign({}, queueItem, {
-                status: "queued"
-            });
+            var storedQueueItem = deepAssign({}, queueItem);
+            storedQueueItem.status = "queued";
             queueItems.push(storedQueueItem);
 
             originalQueueAdd.apply(crawler.queue, arguments);


### PR DESCRIPTION
### PR Checklist

- [x] I have read and/or are familiar with the contributor guidelines
- [x] I have checked to make sure no existing PRs already satisfy the original requirements of this PR
- [x] The commit messages in this PR are clear, and any WIP commits have been squashed
- [x] The code passes lint checking
- [x] The PR contains no spelling or grammatical errors
- [x] Any relevant documentation has been updated
- [x] I have included tests for my code

### What this PR changes

The final puzzle piece that enables asynchronous queue
implementations! It adds an `update` method to the queue that
takes a URL, an object that describes the updates to be made to
the queue item, and a callback.

I've also made sure that all the places where the crawler mutates
queueItems that are *in the queue* now use this method.

And of course, I've added some tests.

### Rationale

See #257 