### PR TITLE
Crawler#respectRobotsTxt now also looks for nofollow robots meta tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,10 @@ change to adapt it to your specific needs.
     Controls whether the crawler should respect rules in robots.txt (if such a
     file is present). The
     [robots-parser](https://www.npmjs.com/package/robots-parser) module is used
-    to do the actual parsing.
+    to do the actual parsing. This property will also make the default
+    `crawler.discoverResources` method respect
+    `<meta name="robots" value="nofollow">` tags - meaning that no resources
+    will be extracted from pages that include such a tag.
 * `crawler.queue` -
     The queue in use by the crawler (Must implement the `FetchQueue` interface)
 * `crawler.allowInitialDomainChange=false` -

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -102,7 +102,10 @@ var Crawler = function(initialURL) {
     this.queue = new FetchQueue();
 
     /**
-     * Controls whether the crawler respects the robots.txt rules of any domain
+     * Controls whether the crawler respects the robots.txt rules of any domain.
+     * This is done both with regards to the robots.txt file, and `<meta>` tags
+     * that specify a `nofollow` value for robots. The latter only applies if
+     * the default {@link Crawler#discoverResources} method is used, though.
      * @type {Boolean}
      */
     this.respectRobotsTxt = true;
@@ -868,6 +871,14 @@ Crawler.prototype.discoverResources = function(resourceText) {
 
     if (!crawler.parseScriptTags) {
         resourceText = resourceText.replace(/<script(.*?)>([\s\S]*?)<\/script>/gi, "");
+    }
+
+    if (crawler.respectRobotsTxt && /<meta[^>]+name=["']robots["'][^>]*>/i.test(resourceText)) {
+        var robotsValue = /<meta[^>]+value=["'](\w+)["'][^>]*>/i.exec(resourceText);
+
+        if (robotsValue[1] === "nofollow") {
+            return [];
+        }
     }
 
     // Rough scan for URLs

--- a/test/discovery.js
+++ b/test/discovery.js
@@ -199,4 +199,10 @@ describe("Crawler link discovery", function() {
         links[0].should.equal("https://example.com/pic-200.png");
         links[1].should.equal("https://example.com/pic-400.png");
     });
+
+    it("should respect nofollow values in robots meta tags", function() {
+
+        var links = discover("<meta name='robots' value='nofollow'><a href='/stage2'>Don't follow me!</a>");
+        links.should.eql([]);
+    });
 });

--- a/test/lib/routes.js
+++ b/test/lib/routes.js
@@ -42,7 +42,15 @@ module.exports = {
     },
 
     "/stage6": function(write) {
+        write(200, "<a href='nofollow'>Go to me, but no further!</a>");
+    },
+
+    "/stage7": function(write) {
         write(200, "Crawl complete!");
+    },
+
+    "/nofollow": function(write) {
+        write(200, "<meta name='robots' value='nofollow'><a href='/stage7'>Don't go here!</a>");
     },
 
     "/cookie": function(write) {
@@ -50,7 +58,7 @@ module.exports = {
         expires.setHours(expires.getHours() + 10);
         var cookie = "thing=stuff; expires=" + expires + "; path=/; domain=.localhost";
 
-        write(200, "<a href='/stage6'>Link</a>", { "Set-Cookie": cookie });
+        write(200, "<a href='/stage7'>Link</a>", { "Set-Cookie": cookie });
     },
 
     "/async-stage1": function(write) {

--- a/test/testcrawl.js
+++ b/test/testcrawl.js
@@ -77,11 +77,24 @@ describe("Test Crawl", function() {
         });
 
         crawler.on("complete", function() {
-            linksDiscovered.should.equal(5);
+            linksDiscovered.should.equal(6);
             done();
         });
 
         crawler.start();
+    });
+
+    it("should obey robots meta tags", function(done) {
+        var crawler = makeCrawler("http://127.0.0.1:3000/");
+        crawler.start();
+
+        crawler.on("discoverycomplete", function(queueItem, resources) {
+            if (queueItem.path === "/nofollow") {
+                resources.should.eql([]);
+                crawler.stop(true);
+                done();
+            }
+        });
     });
 
     it("should obey rules in robots.txt", function(done) {
@@ -90,6 +103,7 @@ describe("Test Crawl", function() {
 
         crawler.on("fetchdisallowed", function(parsedURL) {
             parsedURL.path.should.equal("/forbidden");
+            crawler.stop(true);
             done();
         });
     });


### PR DESCRIPTION
### What this PR changes
If the default Crawler#discoverResources method finds a <meta name="robots" value="nofollow"> tag, it will return an empty array.

### Rationale
See #278 