### PR TITLE
Crawler.discoverRegex: Fixed srcset detection

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -15,7 +15,8 @@ var http            = require("http"),
     zlib            = require("zlib"),
     util            = require("util"),
     iconv           = require("iconv-lite"),
-    robotsTxtParser = require("robots-parser");
+    robotsTxtParser = require("robots-parser"),
+    DOMParser       = require("xmldom").DOMParser;
 
 var QUEUE_ITEM_INITIAL_DEPTH = 1;
 
@@ -330,10 +331,29 @@ var Crawler = function(initialURL) {
 
         // Find srcset links
         function(string) {
-            var result = /\ssrcset\s*=\s*(["'])(.*)\1/.exec(string);
-            return Array.isArray(result) ? String(result[2]).split(",").map(function(string) {
-                return string.replace(/\s?\w*$/, "").trim();
-            }) : "";
+            var parser = new DOMParser({
+                errorHandler:{
+                    warning: function() { /* Suppress warnings */ },
+                    error: function() { /* Suppress error messages */ },
+                    fatalError: function() { /* Suppress error messages */ }
+                }
+            });
+            var srcs = [];
+
+            try {
+                var document = parser.parseFromString(string, "text/html");
+
+                var imgs = document.getElementsByTagName("img");
+
+                for (var ctr = 0; ctr < imgs.length; ctr++) {
+                    var srcset = imgs[ctr].getAttribute("srcset").split(",");
+                    srcset.forEach(function(v) {
+                        srcs.push(v.replace(/\s?\w*$/, "").trim());
+                    });
+                }
+            } catch (e) { /* Do nothing */ }
+
+            return srcs;
         },
 
         // Find resources in <meta> redirects. We need to wrap these RegExp's in

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "dependencies": {
     "iconv-lite": "^0.4.13",
     "robots-parser": "^1.0.0",
-    "urijs": "^1.16.1"
+    "urijs": "^1.16.1",
+    "xmldom": "^0.1.22"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/test/discovery.js
+++ b/test/discovery.js
@@ -190,14 +190,15 @@ describe("Crawler link discovery", function() {
     it("should find resources in srcset attributes", function() {
 
         var links =
-            discover("<img src='pic-200.png' srcset='pic-200.png 200px, pic-400.png 400w'>", {
+            discover("<img title='pic-200' src='pic-200.png' srcset='pic-200.png 200px, pic-400.png 400w' width='400' height='300'><img width='400' alt='pic-201' src='pic-201.png' srcset='pic-201.png 200px, pic-401.png 400w' height='300'>", {
                 url: "https://example.com/"
             });
-
         links.should.be.an("array");
-        links.length.should.equal(2);
+        links.length.should.equal(4);
         links[0].should.equal("https://example.com/pic-200.png");
-        links[1].should.equal("https://example.com/pic-400.png");
+        links[1].should.equal("https://example.com/pic-201.png");
+        links[2].should.equal("https://example.com/pic-400.png");
+        links[3].should.equal("https://example.com/pic-401.png");
     });
 
     it("should respect nofollow values in robots meta tags", function() {


### PR DESCRIPTION
## Crawler.discoverRegex: Srcset detection was fixed.

* Srcset attributes of multiple images are detected.
* Extra attributes after srcset are filtered out.
* Xmldom instead of regex is used to extract the attribute.

## Notes

* Xmldom warnings are suppressed in this PR. 