### PR TITLE
Queue.defrost: use Math.min to replace Math.max

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -464,7 +464,7 @@ FetchQueue.prototype.defrost = function(filename, callback) {
             return callback(error);
         }
 
-        queue._oldestUnfetchedIndex = 0;
+        queue._oldestUnfetchedIndex = defrostedQueue.length - 1;
         queue._scanIndex = {};
 
         for (var i = 0; i < defrostedQueue.length; i++) {
@@ -472,7 +472,7 @@ FetchQueue.prototype.defrost = function(filename, callback) {
             queue.push(queueItem);
 
             if (queueItem.status !== "downloaded") {
-                queue._oldestUnfetchedIndex = Math.max(queue._oldestUnfetchedIndex, i);
+                queue._oldestUnfetchedIndex = Math.min(queue._oldestUnfetchedIndex, i);
             }
 
             queue._scanIndex[queueItem.url] = true;


### PR DESCRIPTION
Fixes #339

This patch try to fix `queue._oldestUnfetchedIndex` calculate error
when `queue.deforst(...)` call. This bug causes queue._oldestUnfetchedIndex
always point to the newest element but not oldest one and skip all
previous queued elements.