### PR TITLE
Allow async fetch conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,13 @@ in parentheses.
     Fired when a resource wasn't queued because of a [fetch
     condition](#fetch-conditions).
 * `fetchconditionerror` (queueItem, error) -
-    Fired when one of the fetch condition returns an error. Provides the queue
+    Fired when one of the fetch conditions returns an error. Provides the queue
     item that was processed when the error was encountered as well as the error
     itself.
+* `downloadconditionerror` (queueItem, error) -
+    Fired when one of the download conditions returns an error. Provides the
+    queue item that was processed when the error was encountered as well as the
+    error itself.
 * `fetchstart` (queueItem, requestOptions) -
     Fired when an item is spooled for fetching. If your event handler is
     synchronous, you can modify the crawler request options (including headers
@@ -451,7 +455,9 @@ myCrawler.removeFetchCondition(listener);
 
 While fetch conditions let you determine which resources to put in the queue,
 download conditions offer the same kind of flexible API for determining which
-resources' data to download.
+resources' data to download. Download conditions support both a synchronous and
+an asynchronous API, but *with the next major release, all download conditions
+will be asynchronous.*
 
 Download conditions are evaluated after the headers of a resource have been
 downloaded, if that resource returned an HTTP status between 200 and 299. This
@@ -466,17 +472,17 @@ Download conditions are added in much the same way as fetch conditions, with the
 used to remove the condition later.
 
 ```js
-var conditionID = myCrawler.addDownloadCondition(function(queueItem, response) {
-    return (
+var conditionID = myCrawler.addDownloadCondition(function(queueItem, response, callback) {
+    callback(
         queueItem.stateData.contentType === "image/png" &&
         queueItem.stateData.contentLength < 5 * 1000 * 1000
     );
 });
 ```
 
-Download conditions are called with two arguments: `queueItem` and `response`.
-The former represents the resource that's being fetched ([queue item
-structure](#queue-items)), and the latter is an instance of
+Download conditions are called with three arguments: `queueItem`, `response` and
+`callback`. `queueItem` represents the resource that's being fetched ([queue
+item structure](#queue-items)) and `response` is an instance of
 `http.IncomingMessage`. Please see the [node
 documentation](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
 for that class for more details on what it looks like.
@@ -488,7 +494,7 @@ returned from the `addDownloadCondition` method, or with a reference to the same
 callback function. `crawler.removeDownloadCondition` is the method you'll use:
 
 ```js
-function listener(queueItem, stateData) {
+function listener(queueItem, response, callback) {
     // Do something
 }
 

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -1361,59 +1361,78 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
         // We should just go ahead and get the data
         } else if (response.statusCode >= 200 && response.statusCode < 300) {
 
-            var downloadDenied = crawler._downloadConditions.some(function(callback) {
-                return !callback(queueItem, response);
-            });
+            async.every(crawler._downloadConditions, function(downloadCondition, callback) {
+                if (downloadCondition.length < 3) {
+                    try {
+                        callback(null, downloadCondition(queueItem, response));
+                    } catch (error) {
+                        callback(error);
+                    }
+                } else {
+                    downloadCondition(queueItem, response, callback);
+                }
+            }, function(error, result) {
 
-            if (downloadDenied) {
-                crawler.queue.update(queueItem.id, {
-                    fetched: true,
-                    status: "downloadprevented"
-                }, function(error, queueItem) {
-                    crawler._openRequests.splice(
-                        crawler._openRequests.indexOf(response.req), 1);
-
-                    response.socket.destroy();
-                    /**
-                     * Fired when the downloading of a resource was prevented
-                     * by a download condition
-                     * @event Crawler#downloadprevented
-                     * @param {QueueItem} queueItem           The queue item representing the resource that was halfway fetched
-                     * @param {http.IncomingMessage} response The [http.IncomingMessage]{@link https://nodejs.org/api/http.html#http_class_http_incomingmessage} for the request's response
-                     */
-                    crawler.emit("downloadprevented", queueItem, response);
-                });
-
-                return false;
-            }
-
-            crawler.queue.update(queueItem.id, {
-                status: "headers"
-            }, function(error, queueItem) {
                 if (error) {
-                    return crawler.emit("queueerror", error, queueItem);
+                    /**
+                     * Fired when a download condition returns an error
+                     * @event Crawler#downloadconditionerror
+                     * @param {QueueItem} queueItem The queue item that was processed when the error was encountered
+                     * @param {*}         error
+                     */
+                    crawler.emit("downloadconditionerror", queueItem, error);
+                    return false;
                 }
 
-                // Create a buffer with our response length
-                responseBuffer = new Buffer(responseLength);
-
-                // Only if we're prepared to download non-text resources...
-                if (crawler.downloadUnsupported || crawler.mimeTypeSupported(contentType)) {
-                    response.on("data", receiveData);
-                    response.on("end", processReceivedData);
-                } else {
+                if (!result) {
                     crawler.queue.update(queueItem.id, {
-                        fetched: true
-                    }, function() {
-                        // Remove this request from the open request map
+                        fetched: true,
+                        status: "downloadprevented"
+                    }, function(error, queueItem) {
                         crawler._openRequests.splice(
                             crawler._openRequests.indexOf(response.req), 1);
 
                         response.socket.destroy();
+                        /**
+                         * Fired when the downloading of a resource was prevented
+                         * by a download condition
+                         * @event Crawler#downloadprevented
+                         * @param {QueueItem} queueItem           The queue item representing the resource that was halfway fetched
+                         * @param {http.IncomingMessage} response The [http.IncomingMessage]{@link https://nodejs.org/api/http.html#http_class_http_incomingmessage} for the request's response
+                         */
+                        crawler.emit("downloadprevented", queueItem, response);
+                    });
+
+                } else {
+                    crawler.queue.update(queueItem.id, {
+                        status: "headers"
+                    }, function(error, queueItem) {
+                        if (error) {
+                            return crawler.emit("queueerror", error, queueItem);
+                        }
+
+                        // Create a buffer with our response length
+                        responseBuffer = new Buffer(responseLength);
+
+                        // Only if we're prepared to download non-text resources...
+                        if (crawler.downloadUnsupported || crawler.mimeTypeSupported(contentType)) {
+                            response.on("data", receiveData);
+                            response.on("end", processReceivedData);
+                        } else {
+                            crawler.queue.update(queueItem.id, {
+                                fetched: true
+                            }, function() {
+                                // Remove this request from the open request map
+                                crawler._openRequests.splice(
+                                    crawler._openRequests.indexOf(response.req), 1);
+
+                                response.socket.destroy();
+                            });
+                        }
+
+                        crawler._isFirstRequest = false;
                     });
                 }
-
-                crawler._isFirstRequest = false;
             });
 
         // We've got a not-modified response back

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -12,6 +12,7 @@ var http            = require("http"),
     https           = require("https"),
     EventEmitter    = require("events").EventEmitter,
     uri             = require("urijs"),
+    async           = require("async"),
     zlib            = require("zlib"),
     util            = require("util"),
     iconv           = require("iconv-lite"),
@@ -1010,14 +1011,17 @@ Crawler.prototype.queueLinkedItems = function(resourceData, queueItem) {
  * Queues a URL for fetching after cleaning, validating and constructing a queue
  * item from it. If you're queueing a URL manually, use this method rather than
  * {@link Crawler#queue#add}
+ * @fires Crawler#invaliddomain
  * @fires Crawler#fetchdisallowed
+ * @fires Crawler#fetchconditionerror
+ * @fires Crawler#fetchprevented
  * @fires Crawler#queueduplicate
  * @fires Crawler#queueerror
  * @fires Crawler#queueadd
  * @param {String} url            An absolute or relative URL. If relative, {@link Crawler#processURL} will make it absolute to the referrer queue item.
  * @param {QueueItem} [referrer]  The queue item representing the resource where this URL was discovered.
  * @param {Boolean} [force]       If true, the URL will be queued regardless of whether it already exists in the queue or not.
- * @return {Boolean}              Returns a boolean indicating whether the URL was queued or not. Fetch conditions, robots.txt rules or errors can prevent the URL from being queued.
+ * @return {Boolean}              The return value used to indicate whether the URL passed all fetch conditions and robots.txt rules. With the advent of async fetch conditions, the return value will no longer take fetch conditions into account.
  */
 Crawler.prototype.queueURL = function(url, referrer, force) {
     var crawler = this,
@@ -1028,28 +1032,61 @@ Crawler.prototype.queueURL = function(url, referrer, force) {
         return false;
     }
 
-    // Pass this URL past fetch conditions to ensure the user thinks it's valid
-    var fetchDenied = crawler._fetchConditions.some(function(callback) {
-        return !callback(queueItem, referrer);
-    });
-
-    if (fetchDenied) {
-        // Fetch conditions conspired to block URL
+    // Check that the domain is valid before adding it to the queue
+    if (!crawler.domainValid(queueItem.host)) {
+        /**
+         * Fired when a resource wasn't queued because of an invalid domain name
+         * @event Crawler#invaliddomain
+         * @param {QueueItem} queueItem The queue item representing the disallowed URL
+         */
+        crawler.emit("invaliddomain", queueItem);
         return false;
     }
 
     if (!crawler.urlIsAllowed(queueItem.url)) {
         /**
-         * Fired when a the fetching of a resource was disallowed by the site's robots.txt rules
+         * Fired when a resource wasn't queued because it was disallowed by the
+         * site's robots.txt rules
          * @event Crawler#fetchdisallowed
-         * @param {QueueItem} queueItem The queue item for which the resource was disallowed
+         * @param {QueueItem} queueItem The queue item representing the disallowed URL
          */
         crawler.emit("fetchdisallowed", queueItem);
         return false;
     }
 
-    // Check the domain is valid before adding it to the queue
-    if (crawler.domainValid(queueItem.host)) {
+    async.every(crawler._fetchConditions, function(fetchCondition, callback) {
+        if (fetchCondition.length < 3) {
+            try {
+                callback(null, fetchCondition(queueItem, referrer));
+            } catch (error) {
+                callback(error);
+            }
+        } else {
+            fetchCondition(queueItem, referrer, callback);
+        }
+    }, function(error, result) {
+        if (error) {
+            /**
+             * Fired when a fetch condition returns an error
+             * @event Crawler#fetchconditionerror
+             * @param {QueueItem} queueItem The queue item that was processed when the error was encountered
+             * @param {*}         error
+             */
+            crawler.emit("fetchconditionerror", queueItem, error);
+            return false;
+        }
+
+        if (!result) {
+            /**
+             * Fired when a fetch condition prevented the queueing of a URL
+             * @event Crawler#fetchprevented
+             * @param {QueueItem} queueItem      The queue item that didn't pass the fetch conditions
+             * @param {Function}  fetchCondition The first fetch condition that returned false
+             */
+            crawler.emit("fetchprevented", queueItem);
+            return false;
+        }
+
         crawler.queue.add(queueItem, force, function(error) {
             if (error) {
                 if (error.code && error.code === "DUPLICATE") {
@@ -1079,7 +1116,7 @@ Crawler.prototype.queueURL = function(url, referrer, force) {
              */
             crawler.emit("queueadd", queueItem, referrer);
         });
-    }
+    });
 
     return true;
 };

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
+    "async": "^2.1.4",
     "iconv-lite": "^0.4.13",
     "robots-parser": "^1.0.0",
     "urijs": "^1.16.1"

--- a/test/conditions.js
+++ b/test/conditions.js
@@ -304,7 +304,7 @@ describe("Download conditions", function() {
             response.should.be.an("object");
             response.should.be.an.instanceof(http.IncomingMessage);
 
-            crawler.stop();
+            crawler.stop(true);
             done();
         });
 
@@ -316,7 +316,7 @@ describe("Download conditions", function() {
             queueItem.should.be.an("object");
             error.should.be.an.instanceof(Error);
 
-            crawler.stop();
+            crawler.stop(true);
             done();
         };
     }


### PR DESCRIPTION
## What this PR changes
It allows async fetch conditions, while maintaining compatibility with previous, synchronous API.

## Rationale
Fixes #345 

@cgiffard comments are welcome! I've added the async dependency to make it easy to asynchronously iterate over the fetch conditions array. Perhaps we could make more use of this module in the future as well. I've also added three new events: `invaliddomain`, `fetchprevented` and `fetchconditionerror`. I went down the verbose route and tried to add more rather than fewer events, but it's probably open for discussion whether or not we need all three of them.
