### PR TITLE
Ticapix/fix srcset discovery

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -332,7 +332,7 @@ var Crawler = function(initialURL) {
         function(string) {
             var result = /\ssrcset\s*=\s*(["'])(.*)\1/.exec(string);
             return Array.isArray(result) ? String(result[2]).split(",").map(function(string) {
-                return string.replace(/\s?\w*$/, "").trim();
+                return string.trim().split(/\s+/)[0];
             }) : "";
         },
 

--- a/test/discovery.js
+++ b/test/discovery.js
@@ -188,16 +188,18 @@ describe("Crawler link discovery", function() {
     });
 
     it("should find resources in srcset attributes", function() {
-
+        // http://w3c.github.io/html/semantics-embedded-content.html#element-attrdef-img-srcset
         var links =
-            discover("<img src='pic-200.png' srcset='pic-200.png 200px, pic-400.png 400w'>", {
+            discover("<img src='pic.png' srcset='pic-200.png, pic-400.png 400w, pic-800.png 800w 2x'>", {
                 url: "https://example.com/"
             });
 
         links.should.be.an("array");
-        links.length.should.equal(2);
-        links[0].should.equal("https://example.com/pic-200.png");
-        links[1].should.equal("https://example.com/pic-400.png");
+        links.length.should.equal(4);
+        links[0].should.equal("https://example.com/pic.png");
+        links[1].should.equal("https://example.com/pic-200.png");
+        links[2].should.equal("https://example.com/pic-400.png");
+        links[3].should.equal("https://example.com/pic-800.png");
     });
 
     it("should respect nofollow values in robots meta tags", function() {

--- a/test/discovery.js
+++ b/test/discovery.js
@@ -188,9 +188,8 @@ describe("Crawler link discovery", function() {
     });
 
     it("should find resources in srcset attributes", function() {
-        // http://w3c.github.io/html/semantics-embedded-content.html#element-attrdef-img-srcset
         var links =
-            discover("<img src='pic.png' srcset='pic-200.png, pic-400.png 400w, pic-800.png 800w 2x'>", {
+            discover("<img src='pic.png' srcset='pic-200.png, pic-400.png 400w, pic-800.png 2x'>", {
                 url: "https://example.com/"
             });
 


### PR DESCRIPTION
## What this PR changes
changed the default discovery function to properly detect srcset url according to the specs

## Rationale
srcset discovery function wasn't parsing correctly url with zero or more than 2 args.
Added a test as an exemple.