### PR TITLE
Fix deleting requestOptions.port when blank/no port set

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -536,7 +536,7 @@ Crawler.prototype.getRequestOptions = function(queueItem) {
     }
 
     // If port is one of the HTTP/HTTPS defaults, delete the option to avoid conflicts
-    if (requestPort === 80 || requestPort === 443 || requestPort === "") {
+    if (requestPort === 80 || requestPort === 443 || !requestPort) {
         delete requestOptions.port;
     }
 

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -536,7 +536,7 @@ Crawler.prototype.getRequestOptions = function(queueItem) {
     }
 
     // If port is one of the HTTP/HTTPS defaults, delete the option to avoid conflicts
-    if (requestPort === 80 || requestPort === 443) {
+    if (requestPort === 80 || requestPort === 443 || requestPort === "") {
         delete requestOptions.port;
     }
 


### PR DESCRIPTION

## What this PR changes
Deletes requestOptions.port when default blank / no port returned, same as it does when port 80 or 443 specified. 

## Rationale
Currently the getRequestOptions() method in crawler.js deletes the port setting when it's set to a default 80 or 443, but I noticed when connecting in a different https agent that the default port is often blank which should also be deleted here I believe. 

This then fixes also an issue an issue I experienced when using `proxy-agent` as the httpAgent & httpsAgent where for HTTPS requests the port would end up as 80 when passed over as blank. 

Hope this makes sense, thanks.
