### PR TITLE
Change cleanExpandResources to work async

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -812,54 +812,55 @@ function cleanURL (URL, queueItem) {
  * URL of the queueItem argument.
  * @param  {Array} urlMatch      An array of URL's
  * @param  {QueueItem} queueItem The queue item representing the resource where the URL's were discovered
- * @return {Array}               Returns an array of unique and absolute URL's
+ * @param  {Function} callback   Function to be called after cleanExpandResources finishes with the new array of cleaned resources.
  */
-Crawler.prototype.cleanExpandResources = function(urlMatch, queueItem) {
+Crawler.prototype.cleanExpandResources = function(urlMatch, queueItem, callback) {
     var crawler = this;
 
     if (!urlMatch) {
         return [];
     }
 
-    return urlMatch
+    var urls = urlMatch
         .filter(Boolean)
         .map(function(url) {
             return cleanURL(url, queueItem);
-        })
-        .reduce(function(list, URL) {
+        });
 
-            // Ensure URL is whole and complete
-            try {
-                URL = uri(URL)
-                    .absoluteTo(queueItem.url || "")
-                    .normalize()
-                    .href();
-            } catch (e) {
-                // But if URI.js couldn't parse it - nobody can!
-                return list;
-            }
+    async.reduce(urls, [], function(list, URL, next) {
 
-            // If we hit an empty item, don't return it
-            if (!URL.length) {
-                return list;
-            }
+        // Ensure URL is whole and complete
+        try {
+            URL = uri(URL)
+                .absoluteTo(queueItem.url || "")
+                .normalize()
+                .href();
+        } catch (e) {
+            // But if URI.js couldn't parse it - nobody can!
+            return setImmediate(next, null, list);
+        }
 
-            // If we don't support the protocol in question
-            if (!crawler.protocolSupported(URL)) {
-                return list;
-            }
+        // If we hit an empty item, don't return it
+        if (!URL.length) {
+            return setImmediate(next, null, list);
+        }
 
-            // Does the item already exist in the list?
-            var exists = list.some(function(entry) {
-                return entry === URL;
-            });
+        // If we don't support the protocol in question
+        if (!crawler.protocolSupported(URL)) {
+            return setImmediate(next, null, list);
+        }
 
-            if (exists) {
-                return list;
-            }
+        // Does the item already exist in the list?
+        var exists = list.some(function(entry) {
+            return entry === URL;
+        });
 
-            return list.concat(URL);
-        }, []);
+        if (exists) {
+            return setImmediate(next, null, list);
+        }
+
+        return setImmediate(next, null, list.concat(URL));
+    }, callback);
 };
 
 /**
@@ -982,25 +983,35 @@ Crawler.prototype.domainValid = function(host) {
  * @fires  Crawler#discoverycomplete
  * @param  {String|Buffer} resourceData The document body to search for URL's
  * @param  {QueueItem} queueItem        The queue item that represents the fetched document body
+ * @param  {Function} callback          Function to be called after Items are linked.
  * @return {Crawler}                    Returns the crawler instance to enable chained API calls
  */
-Crawler.prototype.queueLinkedItems = function(resourceData, queueItem) {
+Crawler.prototype.queueLinkedItems = function(resourceData, queueItem, callback) {
     var crawler = this;
 
     var resources = crawler.discoverResources(resourceData.toString(), queueItem);
-    resources = crawler.cleanExpandResources(resources, queueItem);
 
-    /**
-     * Fired when a request times out
-     * @event Crawler#fetchtimeout
-     * @param {QueueItem} queueItem The queue item for which the request timed out
-     * @param {Number} timeout      The delay in milliseconds after which the request timed out
-     */
-    crawler.emit("discoverycomplete", queueItem, resources);
+    crawler.cleanExpandResources(resources, queueItem, function(err, cleanedResources) {
+        if (err) {
+            return callback(err);
+        }
 
-    resources.forEach(function(url) {
-        if (crawler.maxDepth === 0 || queueItem.depth + 1 <= crawler.maxDepth) {
-            crawler.queueURL(url, queueItem);
+        /**
+         * Fired when a request times out
+         * @event Crawler#fetchtimeout
+         * @param {QueueItem} queueItem The queue item for which the request timed out
+         * @param {Number} timeout      The delay in milliseconds after which the request timed out
+         */
+        crawler.emit("discoverycomplete", queueItem, cleanedResources);
+
+        cleanedResources.forEach(function(url) {
+            if (crawler.maxDepth === 0 || queueItem.depth + 1 <= crawler.maxDepth) {
+                crawler.queueURL(url, queueItem);
+            }
+        });
+
+        if (callback) {
+            callback(null, crawler);
         }
     });
 

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -837,17 +837,23 @@ Crawler.prototype.cleanExpandResources = function(urlMatch, queueItem, callback)
                 .href();
         } catch (e) {
             // But if URI.js couldn't parse it - nobody can!
-            return setImmediate(next, null, list);
+            return process.nextTick(function() {
+                next(null, list);
+            });
         }
 
         // If we hit an empty item, don't return it
         if (!URL.length) {
-            return setImmediate(next, null, list);
+            return process.nextTick(function() {
+                next(null, list);
+            });
         }
 
         // If we don't support the protocol in question
         if (!crawler.protocolSupported(URL)) {
-            return setImmediate(next, null, list);
+            return process.nextTick(function() {
+                next(null, list);
+            });
         }
 
         // Does the item already exist in the list?
@@ -856,10 +862,14 @@ Crawler.prototype.cleanExpandResources = function(urlMatch, queueItem, callback)
         });
 
         if (exists) {
-            return setImmediate(next, null, list);
+            return process.nextTick(function() {
+                next(null, list);
+            });
         }
 
-        return setImmediate(next, null, list.concat(URL));
+        return process.nextTick(function() {
+            next(null, list.concat(URL));
+        });
     }, callback);
 };
 

--- a/test/discovery.js
+++ b/test/discovery.js
@@ -5,208 +5,226 @@
 var chai = require("chai"),
     Crawler = require("../");
 
-chai.should();
+var should = chai.should();
 
-describe("Crawler link discovery", function() {
+describe("Crawler link discovery", function () {
 
     var discover,
         crawler;
 
-    beforeEach(function() {
+    beforeEach(function (done) {
         crawler = new Crawler("http://example.com");
 
-        discover = function (resourceText, queueItem) {
+        discover = function (resourceText, queueItem, callback) {
             queueItem = queueItem || {};
 
             var resources = crawler.discoverResources(resourceText, queueItem);
-            return crawler.cleanExpandResources(resources, queueItem);
+            crawler.cleanExpandResources(resources, queueItem, callback);
         };
+
+        done();
     });
 
-    it("should discover http/s prefixed URLs in the document", function() {
-
-        var links =
-            discover("  blah blah http://google.com/ " +
-                     " blah blah https://fish.com/resource blah " +
-                     " //example.com");
-
-        links.should.be.an("array");
-        links.length.should.equal(2);
-        links[0].should.equal("http://google.com/");
-        links[1].should.equal("https://fish.com/resource");
-    });
-
-    it("should discover URLS in quoted attributes in the document", function() {
-
-        var links =
-            discover("  <a href='google.com'> " +
-                     " <img src=\"http://example.com/resource with spaces.txt\"> " +
-                     " url('thingo.com/test.html')");
-
-        links.should.be.an("array");
-        links.length.should.equal(4);
-        links[0].should.equal("google.com");
-        links[1].should.equal("http://example.com/resource%20with%20spaces.txt");
-        links[2].should.equal("thingo.com/test.html");
-    });
-
-    it("should discover URLS in unquoted attributes in the document", function() {
-
-        var links =
-            discover("  <a href=google.com> " +
-                     " <img src=http://example.com/resource with spaces.txt> " +
-                     " url(thingo.com/test.html)");
-
-        links.should.be.an("array");
-        links.length.should.equal(3);
-        links[0].should.equal("google.com");
-        links[1].should.equal("http://example.com/resource");
-        links[2].should.equal("thingo.com/test.html");
-    });
-
-    it("should replace all '&amp;'s with ampersands", function() {
-
-        var links =
-            discover("<a href='http://example.com/resource?with&amp;query=params&amp;and=entities'>");
-
-        links.should.be.an("array");
-        links.length.should.equal(2);
-        links[0].should.equal("http://example.com/resource?with&query=params&and=entities");
-        links[1].should.equal("http://example.com/resource");
-    });
-
-    it("should replace all '&#38;'s and '&#x00026;'s with ampersands", function() {
-
-        var links =
-            discover("<a href='http://example.com/resource?with&#38;query=params&#x00026;and=entities'>");
-
-        links.should.be.an("array");
-        links.length.should.equal(2);
-        links[0].should.equal("http://example.com/resource?with&query=params&and=entities");
-        links[1].should.equal("http://example.com/resource");
-    });
-
-    it("should find and follow meta redirects", function() {
-
-        var links =
-            discover("<meta http-equiv='refresh' content='0; url=/my/other/page.html'>", {
-                url: "http://example.com/"
+    it("should discover http/s prefixed URLs in the document", function () {
+        discover("  blah blah http://google.com/ " +
+            " blah blah https://fish.com/resource blah " +
+            " //example.com", null,
+            function (err, links) {
+                should.not.exist(err);
+                links.should.be.an("array");
+                links.length.should.equal(2);
+                links[0].should.equal("http://google.com/");
+                links[1].should.equal("https://fish.com/resource");
             });
-
-        links.should.be.an("array");
-        links.length.should.equal(1);
-        links[0].should.equal("http://example.com/my/other/page.html");
     });
 
-    it("should ignore HTML comments with parseHTMLComments = false", function() {
+    it("should discover URLS in quoted attributes in the document", function () {
+
+
+        discover("  <a href='google.com'> " +
+            " <img src=\"http://example.com/resource with spaces.txt\"> " +
+            " url('thingo.com/test.html')", null,
+            function (err, links) {
+                should.not.exist(err);
+                links.should.be.an("array");
+                links.length.should.equal(4);
+                links[0].should.equal("google.com");
+                links[1].should.equal("http://example.com/resource%20with%20spaces.txt");
+                links[2].should.equal("thingo.com/test.html");
+            });
+    });
+
+    it("should discover URLS in unquoted attributes in the document", function () {
+        discover("  <a href=google.com> " +
+            " <img src=http://example.com/resource with spaces.txt> " +
+            " url(thingo.com/test.html)", null,
+            function (err, links) {
+                should.not.exist(err);
+                links.should.be.an("array");
+                links.length.should.equal(3);
+                links[0].should.equal("google.com");
+                links[1].should.equal("http://example.com/resource");
+                links[2].should.equal("thingo.com/test.html");
+
+            });
+    });
+
+    it("should replace all '&amp;'s with ampersands", function () {
+
+        discover("<a href='http://example.com/resource?with&amp;query=params&amp;and=entities'>", null,
+            function (err, links) {
+                should.not.exist(err);
+                links.should.be.an("array");
+                links.length.should.equal(2);
+                links[0].should.equal("http://example.com/resource?with&query=params&and=entities");
+                links[1].should.equal("http://example.com/resource");
+            });
+    });
+
+    it("should replace all '&#38;'s and '&#x00026;'s with ampersands", function () {
+
+        discover("<a href='http://example.com/resource?with&#38;query=params&#x00026;and=entities'>", null,
+            function (err, links) {
+                should.not.exist(err);
+                links.should.be.an("array");
+                links.length.should.equal(2);
+                links[0].should.equal("http://example.com/resource?with&query=params&and=entities");
+                links[1].should.equal("http://example.com/resource");
+            });
+    });
+
+    it("should find and follow meta redirects", function () {
+
+        discover("<meta http-equiv='refresh' content='0; url=/my/other/page.html'>", {
+            url: "http://example.com/"
+        }, function (err, links) {
+            should.not.exist(err);
+            links.should.be.an("array");
+            links.length.should.equal(1);
+            links[0].should.equal("http://example.com/my/other/page.html");
+        });
+    });
+
+    it("should ignore HTML comments with parseHTMLComments = false", function () {
 
         crawler.parseHTMLComments = false;
 
-        var links =
-            discover("  <!-- http://example.com/oneline_comment --> " +
-                     " <a href=google.com> " +
-                     " <!-- " +
-                     " http://example.com/resource " +
-                     " <a href=example.com> " +
-                     " -->");
-
-        links.should.be.an("array");
-        links.length.should.equal(1);
-        links[0].should.equal("google.com");
+        discover("  <!-- http://example.com/oneline_comment --> " +
+            " <a href=google.com> " +
+            " <!-- " +
+            " http://example.com/resource " +
+            " <a href=example.com> " +
+            " -->", null,
+            function (err, links) {
+                should.not.exist(err);
+                links.should.be.an("array");
+                links.length.should.equal(1);
+                links[0].should.equal("google.com");
+            });
     });
 
-    it("should ignore script tags with parseScriptTags = false", function() {
+    it("should ignore script tags with parseScriptTags = false", function () {
 
         crawler.parseScriptTags = false;
 
-        var links =
-            discover("  <script>var a = \"<a href='http://example.com/oneline_script'></a>\";</script> " +
-                     " <a href=google.com> " +
-                     " <script type='text/javascript'> " +
-                     " http://example.com/resource " +
-                     " <a href=example.com> " +
-                     " </SCRIPT>");
-
-        links.should.be.an("array");
-        links.length.should.equal(1);
-        links[0].should.equal("google.com");
+        discover("  <script>var a = \"<a href='http://example.com/oneline_script'></a>\";</script> " +
+            " <a href=google.com> " +
+            " <script type='text/javascript'> " +
+            " http://example.com/resource " +
+            " <a href=example.com> " +
+            " </SCRIPT>", null,
+            function (err, links) {
+                should.not.exist(err);
+                links.should.be.an("array");
+                links.length.should.equal(1);
+                links[0].should.equal("google.com");
+            });
     });
 
-    it("should discover URLs legitimately ending with a quote or parenthesis", function() {
+    it("should discover URLs legitimately ending with a quote or parenthesis", function () {
 
-        var links =
-            discover("<a href='example.com/resource?with(parentheses)'>" +
-                     " <a href='example.com/resource?with\"double quotes\"'>" +
-                     " <a href=\"example.com/resource?with'single quotes'\">");
-
-        links.should.be.an("array");
-        links.length.should.equal(3);
-        links[0].should.equal("example.com/resource?with%28parentheses%29");
-        links[1].should.equal("example.com/resource?with%22double+quotes%22");
-        links[2].should.equal("example.com/resource?with%27single+quotes%27");
+        discover("<a href='example.com/resource?with(parentheses)'>" +
+            " <a href='example.com/resource?with\"double quotes\"'>" +
+            " <a href=\"example.com/resource?with'single quotes'\">", null,
+            function (err, links) {
+                should.not.exist(err);
+                links.should.be.an("array");
+                links.length.should.equal(3);
+                links[0].should.equal("example.com/resource?with%28parentheses%29");
+                links[1].should.equal("example.com/resource?with%22double+quotes%22");
+                links[2].should.equal("example.com/resource?with%27single+quotes%27");
+            });
     });
 
     it("should discard 'javascript:' links except for any arguments in there passed to functions", function () {
 
-        var links =
-            discover("<a href='javascript:;'>" +
-                     " <a href='javascript: void(0);'>" +
-                     " <a href='javascript: goToURL(\"/page/one\")'>", {
-                         url: "http://example.com/"
-                     });
-
-        links.should.be.an("array");
-        links.length.should.equal(2);
-        links[0].should.equal("http://example.com/");
-        links[1].should.equal("http://example.com/page/one");
+        discover("<a href='javascript:;'>" +
+            " <a href='javascript: void(0);'>" +
+            " <a href='javascript: goToURL(\"/page/one\")'>", {
+                url: "http://example.com/"
+            }, function (err, links) {
+                should.not.exist(err);
+                links.should.be.an("array");
+                links.length.should.equal(2);
+                links[0].should.equal("http://example.com/");
+                links[1].should.equal("http://example.com/page/one");
+            });
     });
 
     it("should not pick up 'href' or 'src' inside href attributes as full URL's", function () {
 
-        var links =
-            discover("<a href='https://example.com/?src=3'>My web page</a>");
-
-        links.should.be.an("array");
-        links.length.should.equal(2);
-        links[0].should.equal("https://example.com/?src=3");
-        links[1].should.equal("https://example.com/");
+        discover("<a href='https://example.com/?src=3'>My web page</a>", null,
+            function (err, links) {
+                should.not.exist(err);
+                links.should.be.an("array");
+                links.length.should.equal(2);
+                links[0].should.equal("https://example.com/?src=3");
+                links[1].should.equal("https://example.com/");
+            });
     });
 
     it("should strip fragment identifiers from URL's", function () {
 
-        var links =
-            discover("<a href='https://example.com/#section'>My web page</a>" +
-                     "<a href='/other/page#blabla'>Link</a>" +
-                     "<a href='#section'>Section</a>", {
-                         url: "https://example.com/"
-                     });
-
-        links.should.be.an("array");
-        links.length.should.equal(2);
-        links[0].should.equal("https://example.com/");
-        links[1].should.equal("https://example.com/other/page");
+        discover("<a href='https://example.com/#section'>My web page</a>" +
+            "<a href='/other/page#blabla'>Link</a>" +
+            "<a href='#section'>Section</a>", {
+                url: "https://example.com/"
+            }, function (err, links) {
+                should.not.exist(err);
+                links.should.be.an("array");
+                links.length.should.equal(2);
+                links[0].should.equal("https://example.com/");
+                links[1].should.equal("https://example.com/other/page");
+            });
     });
 
-    it("should find resources in srcset attributes", function() {
-        var links =
-            discover("<img src='pic.png' srcset='pic-200.png, pic-400.png 400w, pic-800.png 2x'>", {
-                url: "https://example.com/"
+    it("should find resources in srcset attributes", function () {
+
+        discover("<img src='pic.png' srcset='pic-200.png, pic-400.png 400w, pic-800.png 2x'>", {
+            url: "https://example.com/"
+        }, function (err, links) {
+            should.not.exist(err);
+            links.should.be.an("array");
+            links.length.should.equal(4);
+            links[0].should.equal("https://example.com/pic.png");
+            links[1].should.equal("https://example.com/pic-200.png");
+            links[2].should.equal("https://example.com/pic-400.png");
+            links[3].should.equal("https://example.com/pic-800.png");
+        });
+    });
+
+    it("should respect nofollow values in robots meta tags", function () {
+
+        discover("<meta name='robots' value='nofollow'><a href='/stage2'>Don't follow me!</a>", null,
+            function (err, links) {
+                should.not.exist(err);
+                links.should.eql([]);
             });
 
-        links.should.be.an("array");
-        links.length.should.equal(4);
-        links[0].should.equal("https://example.com/pic.png");
-        links[1].should.equal("https://example.com/pic-200.png");
-        links[2].should.equal("https://example.com/pic-400.png");
-        links[3].should.equal("https://example.com/pic-800.png");
-    });
-
-    it("should respect nofollow values in robots meta tags", function() {
-
-        discover("<meta name='robots' value='nofollow'><a href='/stage2'>Don't follow me!</a>")
-            .should.eql([]);
-
-        discover("<meta name='robots' value='nofollow, noindex'><a href='/stage2'>Don't follow me!</a>")
-            .should.eql([]);
+        discover("<meta name='robots' value='nofollow, noindex'><a href='/stage2'>Don't follow me!</a>", null,
+            function (err, links) {
+                should.not.exist(err);
+                links.should.eql([]);
+            });
     });
 });

--- a/test/reliability.js
+++ b/test/reliability.js
@@ -183,8 +183,10 @@ describe("Crawler reliability", function() {
                 // queue._oldestUnfetchedItem reviving properly
                 localCrawler.queueURL("http://127.0.0.1:3000/stage/4");
 
-                // Lets the queue be populated
-                process.nextTick(testFreezeDefrost);
+                // Lets the queue be populated (wait two ticks)
+                process.nextTick(function() {
+                    process.nextTick(testFreezeDefrost);
+                });
             }
         });
 


### PR DESCRIPTION
## What this PR changes
- changed cleanExpandResources to work async via multiple ticks (process.nextTick) by change Array.reduce to async.reduce (package was already in project)
- added callbacks and adapted tests for that

## Rationale
related to Issue #364 

This will not improve performence. To do that, we would need a lot of more changes in architecture. But it will stop cleanExpandResources to block the whole process. With that it is possible that a package that uses simplecrawler can do it's stuff and has not to wait over hours. (In Our case we have an interval for logging and such stuff which was blocked before)
