### PR TITLE
Change cache backend parameter to a function

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -13,7 +13,7 @@ var FilesystemBackend = require("./cache-backend-fs.js");
 var Cache = function Cache(cacheLoadParameter, cacheBackend) {
 
     // Ensure parameters are how we want them...
-    cacheBackend = typeof cacheBackend === "object" ? cacheBackend : FilesystemBackend;
+    cacheBackend = typeof cacheBackend === "function" ? cacheBackend : FilesystemBackend;
     cacheLoadParameter = cacheLoadParameter instanceof Array ? cacheLoadParameter : [cacheLoadParameter];
 
     // Now we can just run the factory.


### PR DESCRIPTION
## What this PR changes
The cache backends parameter did not work. It was originally asking for an object, but treating the object like a function. I've changed it to a function that returns an object.
