### PR TITLE
Performance tuning for very large sitemaps.

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -832,52 +832,52 @@ function cleanURL (URL, queueItem) {
  * @param  {QueueItem} queueItem The queue item representing the resource where the URL's were discovered
  * @return {Array}               Returns an array of unique and absolute URL's
  */
-Crawler.prototype.cleanExpandResources = function(urlMatch, queueItem) {
+Crawler.prototype.cleanExpandResources = function (urlMatch, queueItem) {
     var crawler = this;
 
     if (!urlMatch) {
         return [];
     }
+    const URLs = new Set();
+    let URL;
+    for (let i = 0; length = urlMatch.length, i < length; i++) {
+        URL = urlMatch[i];
+        
+        if(URL == false) {
+            continue;
+        }
 
-    return urlMatch
-        .filter(Boolean)
-        .map(function(url) {
-            return cleanURL(url, queueItem);
-        })
-        .reduce(function(list, URL) {
+        URL = cleanURL(URL, queueItem);
 
-            // Ensure URL is whole and complete
-            try {
-                URL = uri(URL)
-                    .absoluteTo(queueItem.url || "")
-                    .normalize()
-                    .href();
-            } catch (e) {
-                // But if URI.js couldn't parse it - nobody can!
-                return list;
-            }
+        // Ensure URL is whole and complete
+        try {
+            URL = uri(URL)
+                .absoluteTo(queueItem.url || "")
+                .normalize()
+                .href();
+        } catch (e) {
+            // But if URI.js couldn't parse it - nobody can!
+            continue;
+        }
 
-            // If we hit an empty item, don't return it
-            if (!URL.length) {
-                return list;
-            }
+        // If we hit an empty item, don't return it
+        if (!URL.length) {
+            continue;
+        }
 
-            // If we don't support the protocol in question
-            if (!crawler.protocolSupported(URL)) {
-                return list;
-            }
+        // If we don't support the protocol in question
+        if (!crawler.protocolSupported(URL)) {
+            continue;
+        }
 
-            // Does the item already exist in the list?
-            var exists = list.some(function(entry) {
-                return entry === URL;
-            });
+        if (URLs.has(URL)) {
+            continue;
+        }
 
-            if (exists) {
-                return list;
-            }
+        URLs.add(URL);
+    }
 
-            return list.concat(URL);
-        }, []);
+    return Array.from(URLs);
 };
 
 /**


### PR DESCRIPTION
Fixes #364

This replaces Array filter, map and reduce calls in the method cleanExpandResources with a simple for loop because they are very slow for large arrays > O(n^2). Speedup observed was 20x.