### PR TITLE
Performance tuning for very large sitemaps.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
     "root": true,
 
     "env": {
-        "node": true
+        "node": true,
+        "es6": true
     },
 
     "rules": {

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -832,52 +832,53 @@ function cleanURL (URL, queueItem) {
  * @param  {QueueItem} queueItem The queue item representing the resource where the URL's were discovered
  * @return {Array}               Returns an array of unique and absolute URL's
  */
-Crawler.prototype.cleanExpandResources = function(urlMatch, queueItem) {
+Crawler.prototype.cleanExpandResources = function (urlMatch, queueItem) {
     var crawler = this;
 
     if (!urlMatch) {
         return [];
     }
+    var URLs = new Set();
+    var URL;
+    for (var i = 0; i < urlMatch.length; i++) {
+        URL = urlMatch[i];
 
-    return urlMatch
-        .filter(Boolean)
-        .map(function(url) {
-            return cleanURL(url, queueItem);
-        })
-        .reduce(function(list, URL) {
+        /* eslint eqeqeq: "off" */
+        if (URL == false) {
+            continue;
+        }
 
-            // Ensure URL is whole and complete
-            try {
-                URL = uri(URL)
-                    .absoluteTo(queueItem.url || "")
-                    .normalize()
-                    .href();
-            } catch (e) {
-                // But if URI.js couldn't parse it - nobody can!
-                return list;
-            }
+        URL = cleanURL(URL, queueItem);
 
-            // If we hit an empty item, don't return it
-            if (!URL.length) {
-                return list;
-            }
+        // Ensure URL is whole and complete
+        try {
+            URL = uri(URL)
+                .absoluteTo(queueItem.url || "")
+                .normalize()
+                .href();
+        } catch (e) {
+            // But if URI.js couldn't parse it - nobody can!
+            continue;
+        }
 
-            // If we don't support the protocol in question
-            if (!crawler.protocolSupported(URL)) {
-                return list;
-            }
+        // If we hit an empty item, don't return it
+        if (!URL.length) {
+            continue;
+        }
 
-            // Does the item already exist in the list?
-            var exists = list.some(function(entry) {
-                return entry === URL;
-            });
+        // If we don't support the protocol in question
+        if (!crawler.protocolSupported(URL)) {
+            continue;
+        }
 
-            if (exists) {
-                return list;
-            }
+        if (URLs.has(URL)) {
+            continue;
+        }
 
-            return list.concat(URL);
-        }, []);
+        URLs.add(URL);
+    }
+
+    return Array.from(URLs);
 };
 
 /**


### PR DESCRIPTION
Fixes #364 

## What this PR changes
This refactors the cleanExpandResources method in crawler.js to use a single for loop instead of Array.{filter,map,reduce}. The speedup observed was 20x for a sitemap with 20k urls.
To make the set data structure available the Es-lint checker was bumped to ES6.

## Rationale
After creating and analyzing several CPU profiles in Webstorm I decided to get rid of Javascripts native array methods filter, map and reduce, because they are very slow for large arrays. Additionally using a set instead of an array for the result of the reduce part makes a lot more sense because we want to keep unique URLs only.