### PR TITLE
Skip faulty URLs such as those missing a hostname or having an invali…

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -870,8 +870,21 @@ Crawler.prototype.cleanExpandResources = function (urlMatch, queueItem) {
             continue;
         }
 
-        // If we hit an empty item, don't return it
         if (!URL.length) {
+            continue;
+        }
+
+        let parsedUrl = uri(URL);
+
+        // filter broken urls such as http:///
+        if (parsedUrl.protocol().length // has protocol
+            && !parsedUrl.hostname().length // has no hostname
+            && parsedUrl.path().length // has path
+        ) {
+            continue;
+        }
+
+        if (!crawler.portValid(parsedUrl)) {
             continue;
         }
 
@@ -995,6 +1008,35 @@ Crawler.prototype.domainValid = function(host) {
            // Or if we're scanning subdomains, and this domain is a subdomain
            // of the crawler's set domain, return true.
            crawler.scanSubdomains && isSubdomainOf(host, crawler.host);
+};
+
+/**
+ * If the url contains a custom port, verify that it is a valid tcp  port
+ *
+ * @param {String} URL
+ * @param {URI} parsedUrl uri.js instance
+ * @returns {boolean}
+ */
+Crawler.prototype.portValid = function(parsedUrl) {
+    "use strict";
+
+    // URL does not contain a custom port
+    if (parsedUrl.port().length === 0) {
+        return true;
+    }
+
+    let port = Number(parsedUrl.port());
+
+    if (!Number.isInteger(port)) {
+        return false;
+    }
+
+    // verify port is between 1 and 65535
+    if (port > 0 && port < 65536) {
+        return true;
+    }
+
+    return false;
 };
 
 /**


### PR DESCRIPTION
See #385 

This needs fixing either in URI.js or in simplecrawler. I agree that it makes more sense to do it in URI.js, but I think it will take a lot more effort to refactor their validation code.

This prevents the crawler crashing on pages containing links such as
```
<a href="http://">http://</a><br>
<a href="http://hostname:port/foo/bar">http://hostname:port/foo/bar</a>
```