### PR TITLE
Fix AppVeyor configuration.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,4 +34,4 @@ matrix:
     fast_finish: true
 
 cache:
-    - node_modules -> package.json
+    - node_modules -> package.json,package-lock.json


### PR DESCRIPTION
Looks like 30e38b9cad1a86440486d3423446d49b7c7fee70 broke Node.js 8.X tests on AppVeyor.
Fix from https://github.com/appveyor/website/blob/master/appveyor.yml .