### PR TITLE
Use latest URI.js, which has improved validation logic.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "async": "^2.1.4",
     "iconv-lite": "^0.4.13",
     "robots-parser": "^1.0.0",
-    "urijs": "^1.16.1"
+    "urijs": "^1.18.11"
   },
   "devDependencies": {
     "chai": "^3.2.0",


### PR DESCRIPTION
Fixes #385

With these changes simplecrawler will not queue links such as http://server:port or http:// anymore.

See medialize/URI.js#344 and medialize/URI.js#345