### PR TITLE
docs: fix discoverResources signature in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1017,8 +1017,8 @@ It is quite common to pair simplecrawler with a module like [cheerio](https://np
 The example below demonstrates how one might achieve basic HTML-correct discovery of only link tags using cheerio.
 
 ```js
-crawler.discoverResources = function(buffer, queueItem) {
-    var $ = cheerio.load(buffer.toString("utf8"));
+crawler.discoverResources = function(resourceText) {
+    var $ = cheerio.load(resourceText);
 
     return $("a[href]").map(function () {
         return $(this).attr("href");


### PR DESCRIPTION

- *Did you make sure the commit messages are clear, and WIP commits have been squashed?* Yes
- *Did you lint and test the code (`npm test`)?* No code changes
- *Did you include tests for your code?* No code changes
- *If applicable, did you update the documentation with the changes you made?* Yes
- *If you made changes to the docs, did you run a quick spell check?* No (human) language changes

## What this PR changes
`discoverResources` example in README had a `(buffer, queueItem)` signature, whereas it actually receives `(resourceText)`

## Rationale
*If this has been discussed in an issue already, please reference it here!*
